### PR TITLE
Implement BitMex core and ExchangeHub for bot demo

### DIFF
--- a/src/ExchangeHub.ts
+++ b/src/ExchangeHub.ts
@@ -29,10 +29,17 @@ export class ExchangeHub<ExName extends ExchangeName> {
     }
 
     async connect() {
-        //
+        await this.#core.connect();
+
+        this.#instruments = await this.#core.getInstruments();
+
+        for (const instrument of this.#instruments) {
+            instrument.orders = await this.#core.getOrders(instrument);
+        }
     }
 
     async disconnect() {
-        //
+        this.#instruments = [];
+        await this.#core.disconnect();
     }
 }

--- a/src/cores/BaseCore.ts
+++ b/src/cores/BaseCore.ts
@@ -1,4 +1,5 @@
 import type { ExchangeHub } from '../ExchangeHub';
+import type { Instrument, Order } from '../entities';
 import type { ApiKey, ApiSec, ExchangeName, Settings } from '../types';
 
 export class BaseCore {
@@ -27,5 +28,21 @@ export class BaseCore {
 
     get isPublicOnly(): boolean {
         return !(this.#apiKey && this.#apiSec);
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function
+    async connect(): Promise<void> {}
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function
+    async disconnect(): Promise<void> {}
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    async getInstruments(): Promise<Instrument[]> {
+        throw new Error('Method not implemented.');
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    async getOrders(_instrument: Instrument): Promise<Order[]> {
+        return [];
     }
 }

--- a/src/cores/bitmex/index.ts
+++ b/src/cores/bitmex/index.ts
@@ -1,5 +1,101 @@
 import { BaseCore } from '../BaseCore';
+import { Instrument, Order } from '../../entities';
+
+type RawInstrument = { symbol: string };
 
 export class BitMex extends BaseCore {
-    //
+    #restEndpoint: string;
+    #wsEndpoint: string;
+    #ws?: WebSocket;
+
+    constructor(shell: any, settings: any) {
+        super(shell, settings);
+        this.#restEndpoint = this.isTest ? 'https://testnet.bitmex.com' : 'https://www.bitmex.com';
+        this.#wsEndpoint = this.isTest ? 'wss://testnet.bitmex.com/realtime' : 'wss://www.bitmex.com/realtime';
+    }
+
+    async connect(): Promise<void> {
+        this.#ws = new WebSocket(this.#wsEndpoint);
+
+        await new Promise<void>((resolve, reject) => {
+            this.#ws?.addEventListener('open', () => resolve());
+            this.#ws?.addEventListener('error', err => reject(err));
+        });
+    }
+
+    async disconnect(): Promise<void> {
+        if (!this.#ws) return;
+
+        await new Promise<void>(resolve => {
+            this.#ws?.addEventListener('close', () => resolve());
+            this.#ws?.close();
+        });
+
+        this.#ws = undefined;
+    }
+
+    async getInstruments(): Promise<Instrument[]> {
+        const response = await fetch(`${this.#restEndpoint}/api/v1/instrument/active`);
+        const data = (await response.json()) as RawInstrument[];
+
+        return data.map(item => new Instrument(item.symbol));
+    }
+
+    async getOrders(instrument: Instrument): Promise<Order[]> {
+        if (!this.#ws) throw new Error('WebSocket not connected');
+
+        const channel = `orderBook10:${instrument.symbol}`;
+
+        this.#ws.send(JSON.stringify({ op: 'subscribe', args: [channel] }));
+
+        return new Promise<Order[]>((resolve, reject) => {
+            const handleMessage = (event: MessageEvent) => {
+                try {
+                    const text = typeof event.data === 'string' ? event.data : '';
+                    const message = JSON.parse(text);
+
+                    if (message.table === 'orderBook10' && Array.isArray(message.data)) {
+                        const row = message.data.find((d: any) => d.symbol === instrument.symbol);
+
+                        if (!row) return;
+
+                        this.#ws?.removeEventListener('message', handleMessage);
+                        this.#ws?.send(JSON.stringify({ op: 'unsubscribe', args: [channel] }));
+
+                        const orders: Order[] = [];
+
+                        if (row.bids?.length) {
+                            orders.push(
+                                new Order(instrument, {
+                                    id: 0,
+                                    side: 'Buy',
+                                    price: row.bids[0][0],
+                                    size: row.bids[0][1],
+                                }),
+                            );
+                        }
+
+                        if (row.asks?.length) {
+                            orders.push(
+                                new Order(instrument, {
+                                    id: 0,
+                                    side: 'Sell',
+                                    price: row.asks[0][0],
+                                    size: row.asks[0][1],
+                                }),
+                            );
+                        }
+
+                        resolve(orders);
+                    }
+                } catch (err) {
+                    this.#ws?.removeEventListener('message', handleMessage);
+                    reject(err);
+                }
+            };
+
+            this.#ws?.addEventListener('message', handleMessage);
+            this.#ws?.addEventListener('error', reject);
+        });
+    }
 }

--- a/src/entities/Instrument.ts
+++ b/src/entities/Instrument.ts
@@ -15,4 +15,8 @@ export class Instrument {
     get orders(): Order[] {
         return this.#orders;
     }
+
+    set orders(value: Order[]) {
+        this.#orders = value;
+    }
 }

--- a/src/entities/Order.ts
+++ b/src/entities/Order.ts
@@ -1,10 +1,20 @@
 import type { Instrument } from './Instrument';
 
+export type OrderSide = 'Buy' | 'Sell';
+
 export class Order {
     #instrument: Instrument;
+    #id: number;
+    #side: OrderSide;
+    #price: number;
+    #size: number;
 
-    constructor(instrument: Instrument) {
+    constructor(instrument: Instrument, data: { id: number; side: OrderSide; price: number; size: number }) {
         this.#instrument = instrument;
+        this.#id = data.id;
+        this.#side = data.side;
+        this.#price = data.price;
+        this.#size = data.size;
     }
 
     get instrument(): Instrument {
@@ -13,5 +23,21 @@ export class Order {
 
     get symbol(): string {
         return this.#instrument.symbol;
+    }
+
+    get id(): number {
+        return this.#id;
+    }
+
+    get side(): OrderSide {
+        return this.#side;
+    }
+
+    get price(): number {
+        return this.#price;
+    }
+
+    get size(): number {
+        return this.#size;
     }
 }

--- a/src/entities/index.ts
+++ b/src/entities/index.ts
@@ -1,1 +1,2 @@
-export { Order } from './Order';
+export { Order, type OrderSide } from './Order';
+export { Instrument } from './Instrument';


### PR DESCRIPTION
## Summary
- implement ExchangeHub connect/disconnect logic
- add BaseCore hooks, BitMex REST and WebSocket market data implementation
- extend entities to model instruments and order book entries

## Testing
- `npm run lint`
- `npm run format`
- `npm test -- --passWithNoTests`
- `npm run build`
- `node dist/examples/bitmex-bot/index.js` *(fails: UnhandledPromiseRejection: #<_ErrorEvent>)*

------
https://chatgpt.com/codex/tasks/task_e_68b56c2cb7e4832094263c203d489171