### PR TITLE
feat: add websocket auth via api keys

### DIFF
--- a/src/cores/BaseCore.ts
+++ b/src/cores/BaseCore.ts
@@ -30,6 +30,14 @@ export class BaseCore {
         return !(this.#apiKey && this.#apiSec);
     }
 
+    get apiKey(): ApiKey | undefined {
+        return this.#apiKey;
+    }
+
+    get apiSec(): ApiSec | undefined {
+        return this.#apiSec;
+    }
+
     // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function
     async connect(): Promise<void> {}
 


### PR DESCRIPTION
## Summary
- expose api credentials on BaseCore
- authenticate BitMex websocket connections using api keys

## Testing
- `npm test` *(fails: No tests found)*
- `npm run lint`
- `npm run format`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68b70ed6dda88320bdcfd11591c37091