### PR TITLE
Refactor BitMEX WebSocket message handling

### DIFF
--- a/src/cores/bitmex/types.ts
+++ b/src/cores/bitmex/types.ts
@@ -40,3 +40,19 @@ export type TradeMessage = {
     action: 'partial' | 'insert';
     data: BitMexTrade[];
 };
+
+export type WelcomeMessage = {
+    info: string;
+    version: string | number;
+    timestamp?: string;
+    docs?: string;
+};
+
+export type SubscribeMessage = {
+    success: boolean;
+    subscribe: string;
+    request: {
+        op: string;
+        args: string[];
+    };
+};


### PR DESCRIPTION
## Summary
- add types for BitMEX welcome and subscription messages
- parse WebSocket messages once and dispatch using channel handler map
- adjust instrument and trade handlers to operate on parsed messages

## Testing
- `npm test` *(fails: No tests found)*
- `npm run lint`
- `npm run format`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68ba90771b388320978c07cf69a9ea86