### PR TITLE
Add publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,29 @@
+name: Publish
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org
+      - id: versions
+        run: |
+          PACKAGE_NAME=$(node -p "require('./package.json').name")
+          PACKAGE_VERSION=$(node -p "require('./package.json').version")
+          PUBLISHED_VERSION=$(npm view "$PACKAGE_NAME" version || echo "0.0.0")
+          echo "packageVersion=$PACKAGE_VERSION" >> $GITHUB_OUTPUT
+          echo "publishedVersion=$PUBLISHED_VERSION" >> $GITHUB_OUTPUT
+      - name: Publish
+        if: steps.versions.outputs.packageVersion != steps.versions.outputs.publishedVersion
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          npm ci
+          npm publish --access public


### PR DESCRIPTION
## Summary
- publish package to npm on merges to main when version changes

## Testing
- `npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68c51d75b1108320bf3bb6872e6ef1f9