### PR TITLE
feat: add typings for bitmex channels

### DIFF
--- a/src/cores/bitmex/index.ts
+++ b/src/cores/bitmex/index.ts
@@ -7,6 +7,17 @@ import type {
     TradeMessage,
     SubscribeMessage,
     WelcomeMessage,
+    FundingMessage,
+    LiquidationMessage,
+    OrderBookL2Message,
+    SettlementMessage,
+    ExecutionMessage,
+    OrderMessage,
+    MarginMessage,
+    PositionMessage,
+    TransactMessage,
+    WalletMessage,
+    BitMexChannelMessageMap,
 } from './types';
 import { BaseCore } from '../BaseCore';
 import { Asset, Instrument, Order, Trade } from '../../entities';
@@ -19,7 +30,9 @@ export class BitMex extends BaseCore {
     #assetEntities: Map<string, Asset> = new Map();
     #instrumentReady!: Promise<void>;
     #resolveInstrumentReady!: () => void;
-    #channelHandlers: Record<string, (message: any) => void>;
+    #channelHandlers: {
+        [K in keyof BitMexChannelMessageMap]: (message: BitMexChannelMessageMap[K]) => void;
+    };
 
     constructor(shell: any, settings: any) {
         super(shell, settings);
@@ -180,17 +193,19 @@ export class BitMex extends BaseCore {
 
             if (!text) return;
 
-            const message = JSON.parse(text);
+            const message = JSON.parse(text) as BitMexChannelMessageMap[keyof BitMexChannelMessageMap];
 
             if (this.#isWelcomeMessage(message) || this.#isSubscribeMessage(message)) return;
 
-            const table = (message as { table?: string }).table;
+            const table = (message as { table?: keyof BitMexChannelMessageMap }).table;
 
             if (!table) return;
 
-            const handler = this.#channelHandlers[table];
+            const handler = this.#channelHandlers[table] as (
+                msg: BitMexChannelMessageMap[keyof BitMexChannelMessageMap],
+            ) => void;
 
-            handler?.(message);
+            handler?.(message as BitMexChannelMessageMap[keyof BitMexChannelMessageMap]);
         } catch {
             // ignore
         }
@@ -215,43 +230,43 @@ export class BitMex extends BaseCore {
         }
     };
 
-    #handleFundingMessage = (_message: any) => {
+    #handleFundingMessage = (_message: FundingMessage) => {
         // noop
     };
 
-    #handleLiquidationMessage = (_message: any) => {
+    #handleLiquidationMessage = (_message: LiquidationMessage) => {
         // noop
     };
 
-    #handleOrderBookL2Message = (_message: any) => {
+    #handleOrderBookL2Message = (_message: OrderBookL2Message) => {
         // noop
     };
 
-    #handleSettlementMessage = (_message: any) => {
+    #handleSettlementMessage = (_message: SettlementMessage) => {
         // noop
     };
 
-    #handleExecutionMessage = (_message: any) => {
+    #handleExecutionMessage = (_message: ExecutionMessage) => {
         // noop
     };
 
-    #handleOrderMessage = (_message: any) => {
+    #handleOrderMessage = (_message: OrderMessage) => {
         // noop
     };
 
-    #handleMarginMessage = (_message: any) => {
+    #handleMarginMessage = (_message: MarginMessage) => {
         // noop
     };
 
-    #handlePositionMessage = (_message: any) => {
+    #handlePositionMessage = (_message: PositionMessage) => {
         // noop
     };
 
-    #handleTransactMessage = (_message: any) => {
+    #handleTransactMessage = (_message: TransactMessage) => {
         // noop
     };
 
-    #handleWalletMessage = (_message: any) => {
+    #handleWalletMessage = (_message: WalletMessage) => {
         // noop
     };
 

--- a/src/cores/bitmex/types.ts
+++ b/src/cores/bitmex/types.ts
@@ -165,3 +165,121 @@ export type SubscribeMessage = {
         args: string[];
     };
 };
+
+type TableMessage<Table extends string, Data> = {
+    table: Table;
+    action: 'partial' | 'insert' | 'update' | 'delete';
+    data: Data[];
+};
+
+export type BitMexFunding = {
+    timestamp: string;
+    symbol: string;
+    fundingRate: number;
+    fundingRateDaily: number;
+};
+
+export type BitMexLiquidation = {
+    orderID: string;
+    symbol: string;
+    side: 'Buy' | 'Sell';
+    price: number;
+    leavesQty: number;
+};
+
+export type BitMexOrderBookL2 = {
+    symbol: string;
+    id: number;
+    side: 'Buy' | 'Sell';
+    size?: number;
+    price?: number;
+};
+
+export type BitMexSettlement = {
+    timestamp: string;
+    symbol: string;
+    settlementType: string;
+    settlePrice?: number;
+};
+
+export type BitMexExecution = {
+    execID: string;
+    orderID: string;
+    clOrdID?: string;
+    symbol: string;
+    side?: 'Buy' | 'Sell';
+    price?: number;
+    size?: number;
+};
+
+export type BitMexOrder = {
+    orderID: string;
+    clOrdID?: string;
+    symbol: string;
+    side?: 'Buy' | 'Sell';
+    price?: number;
+    orderQty?: number;
+    ordStatus?: string;
+};
+
+export type BitMexMargin = {
+    account: number;
+    currency: string;
+    riskLimit: number;
+    marginBalance: number;
+    availableMargin: number;
+};
+
+export type BitMexPosition = {
+    account: number;
+    symbol: string;
+    currentQty?: number;
+    avgEntryPrice?: number;
+    liquidationPrice?: number;
+};
+
+export type BitMexTransact = {
+    transactID: string;
+    account: number;
+    currency: string;
+    transactType?: string;
+    amount: number;
+    fee?: number;
+    transactStatus?: string;
+    address?: string;
+    timestamp?: string;
+};
+
+export type BitMexWallet = {
+    account: number;
+    currency: string;
+    balance: number;
+    availableMargin?: number;
+    walletBalance?: number;
+};
+
+export type FundingMessage = TableMessage<'funding', BitMexFunding>;
+export type LiquidationMessage = TableMessage<'liquidation', BitMexLiquidation>;
+export type OrderBookL2Message = TableMessage<'orderBookL2', BitMexOrderBookL2>;
+export type SettlementMessage = TableMessage<'settlement', BitMexSettlement>;
+export type ExecutionMessage = TableMessage<'execution', BitMexExecution>;
+export type OrderMessage = TableMessage<'order', BitMexOrder>;
+export type MarginMessage = TableMessage<'margin', BitMexMargin>;
+export type PositionMessage = TableMessage<'position', BitMexPosition>;
+export type TransactMessage = TableMessage<'transact', BitMexTransact>;
+export type WalletMessage = TableMessage<'wallet', BitMexWallet>;
+
+export type BitMexChannelMessageMap = {
+    instrument: InstrumentMessage;
+    trade: TradeMessage;
+    funding: FundingMessage;
+    liquidation: LiquidationMessage;
+    orderBookL2: OrderBookL2Message;
+    settlement: SettlementMessage;
+    execution: ExecutionMessage;
+    order: OrderMessage;
+    margin: MarginMessage;
+    position: PositionMessage;
+    transact: TransactMessage;
+    wallet: WalletMessage;
+};


### PR DESCRIPTION
## Summary
- add types for BitMEX WebSocket channel messages
- wire channel handlers to use new message typings

## Testing
- `npm run check` *(fails: Code style issues found in .github/workflows/publish.yml)*
- `npm run lint`
- `npm run type-check`
- `npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68c5370cf70483208a29397ff859eb0c