### PR TITLE
Refactor BitMex channels and transport layer

### DIFF
--- a/src/cores/bitmex/constants.ts
+++ b/src/cores/bitmex/constants.ts
@@ -8,7 +8,3 @@ export const BITMEX_PUBLIC_CHANNELS = [
 ] as const;
 
 export const BITMEX_PRIVATE_CHANNELS = ['execution', 'order', 'margin', 'position', 'transact', 'wallet'] as const;
-
-export type BitMexPublicChannel = (typeof BITMEX_PUBLIC_CHANNELS)[number];
-export type BitMexPrivateChannel = (typeof BITMEX_PRIVATE_CHANNELS)[number];
-export type BitMexChannel = BitMexPublicChannel | BitMexPrivateChannel;

--- a/src/cores/bitmex/constants.ts
+++ b/src/cores/bitmex/constants.ts
@@ -1,0 +1,14 @@
+export const BITMEX_PUBLIC_CHANNELS = [
+    'instrument',
+    'trade',
+    'funding',
+    'liquidation',
+    'orderBookL2',
+    'settlement',
+] as const;
+
+export const BITMEX_PRIVATE_CHANNELS = ['execution', 'order', 'margin', 'position', 'transact', 'wallet'] as const;
+
+export type BitMexPublicChannel = (typeof BITMEX_PUBLIC_CHANNELS)[number];
+export type BitMexPrivateChannel = (typeof BITMEX_PRIVATE_CHANNELS)[number];
+export type BitMexChannel = BitMexPublicChannel | BitMexPrivateChannel;

--- a/src/cores/bitmex/transport.ts
+++ b/src/cores/bitmex/transport.ts
@@ -1,0 +1,63 @@
+import { createHmac } from 'crypto';
+
+import type { BitMexChannel } from './types';
+
+export class BitMexTransport {
+    #endpoint: string;
+    #ws?: WebSocket;
+
+    constructor(endpoint: string) {
+        this.#endpoint = endpoint;
+    }
+
+    async connect(isPublicOnly: boolean, apiKey?: string, apiSec?: string): Promise<void> {
+        this.#ws = new WebSocket(this.#endpoint);
+
+        await new Promise<void>((resolve, reject) => {
+            this.#ws?.addEventListener('open', () => resolve());
+            this.#ws?.addEventListener('error', err => reject(err));
+        });
+
+        if (!isPublicOnly && apiKey && apiSec) {
+            const expires = Math.round(Date.now() / 1000) + 60;
+            const signature = createHmac('sha256', apiSec).update(`GET/realtime${expires}`).digest('hex');
+
+            this.send({ op: 'authKeyExpires', args: [apiKey, expires, signature] });
+        }
+    }
+
+    async disconnect(): Promise<void> {
+        if (!this.#ws) return;
+
+        await new Promise<void>(resolve => {
+            this.#ws?.addEventListener('close', () => resolve());
+            this.#ws?.close();
+        });
+
+        this.#ws = undefined;
+    }
+
+    isConnected(): boolean {
+        return !!this.#ws;
+    }
+
+    subscribe(channels: BitMexChannel[]): void {
+        this.send({ op: 'subscribe', args: channels });
+    }
+
+    unsubscribe(channels: BitMexChannel[]): void {
+        this.send({ op: 'unsubscribe', args: channels });
+    }
+
+    send(data: any): void {
+        this.#ws?.send(JSON.stringify(data));
+    }
+
+    addEventListener(type: string, listener: (...args: any[]) => void): void {
+        this.#ws?.addEventListener(type, listener as any);
+    }
+
+    removeEventListener(type: string, listener: (...args: any[]) => void): void {
+        this.#ws?.removeEventListener(type, listener as any);
+    }
+}

--- a/src/cores/bitmex/types.ts
+++ b/src/cores/bitmex/types.ts
@@ -1,6 +1,8 @@
-import type { BitMexChannel } from './constants';
+import type { BITMEX_PUBLIC_CHANNELS, BITMEX_PRIVATE_CHANNELS } from './constants';
 
-export type { BitMexChannel } from './constants';
+export type BitMexPublicChannel = (typeof BITMEX_PUBLIC_CHANNELS)[number];
+export type BitMexPrivateChannel = (typeof BITMEX_PRIVATE_CHANNELS)[number];
+export type BitMexChannel = BitMexPublicChannel | BitMexPrivateChannel;
 
 export type BitMexInstrument = {
     symbol: string;

--- a/src/cores/bitmex/types.ts
+++ b/src/cores/bitmex/types.ts
@@ -1,3 +1,7 @@
+import type { BitMexChannel } from './constants';
+
+export type { BitMexChannel } from './constants';
+
 export type BitMexInstrument = {
     symbol: string;
     rootSymbol?: string;
@@ -159,14 +163,14 @@ export type WelcomeMessage = {
 
 export type SubscribeMessage = {
     success: boolean;
-    subscribe: string;
+    subscribe: BitMexChannel;
     request: {
         op: string;
-        args: string[];
+        args: BitMexChannel[];
     };
 };
 
-type TableMessage<Table extends string, Data> = {
+type TableMessage<Table extends BitMexChannel, Data> = {
     table: Table;
     action: 'partial' | 'insert' | 'update' | 'delete';
     data: Data[];


### PR DESCRIPTION
## Summary
- extract BitMex public/private channel lists into constants and derive channel types
- update message types to use channel unions
- introduce BitMexTransport to isolate WebSocket transport and update BitMex core

## Testing
- `npm test -- --passWithNoTests`
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68c53cca21308320a4913e6a519b1343