### PR TITLE
Refactor BitMex entity initialization

### DIFF
--- a/src/ExchangeHub.ts
+++ b/src/ExchangeHub.ts
@@ -30,8 +30,7 @@ export class ExchangeHub<ExName extends ExchangeName> {
 
     async connect() {
         await this.#core.connect();
-
-        this.#instruments = await this.#core.getInstruments();
+        this.#instruments = this.#core.instruments;
     }
 
     async disconnect() {

--- a/src/cores/BaseCore.ts
+++ b/src/cores/BaseCore.ts
@@ -1,5 +1,5 @@
 import type { ExchangeHub } from '../ExchangeHub';
-import type { Instrument, Order } from '../entities';
+import type { Instrument } from '../entities';
 import type { ApiKey, ApiSec, ExchangeName, Settings } from '../types';
 
 export class BaseCore {
@@ -44,13 +44,7 @@ export class BaseCore {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function
     async disconnect(): Promise<void> {}
 
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    async getInstruments(): Promise<Instrument[]> {
-        throw new Error('Method not implemented.');
-    }
-
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    async getOrders(_instrument: Instrument): Promise<Order[]> {
+    get instruments(): Instrument[] {
         return [];
     }
 }

--- a/src/cores/bitmex/index.ts
+++ b/src/cores/bitmex/index.ts
@@ -32,6 +32,9 @@ export class BitMex extends BaseCore {
     #assetEntities: Map<string, Asset> = new Map();
     #instrumentReady!: Promise<void>;
     #resolveInstrumentReady!: () => void;
+    #orderBookLevels: Map<string, Map<number, { side: 'Buy' | 'Sell'; price: number; size: number }>> = new Map();
+    #orderBookReady!: Promise<void>;
+    #resolveOrderBookReady!: () => void;
     #channelHandlers: {
         [K in BitMexChannel]: (message: BitMexChannelMessageMap[K]) => void;
     };
@@ -62,6 +65,9 @@ export class BitMex extends BaseCore {
         this.#instrumentReady = new Promise(resolve => {
             this.#resolveInstrumentReady = resolve;
         });
+        this.#orderBookReady = new Promise(resolve => {
+            this.#resolveOrderBookReady = resolve;
+        });
 
         this.#transport.addEventListener('message', this.#handleMessage);
 
@@ -70,6 +76,8 @@ export class BitMex extends BaseCore {
         ) as BitMexChannel[];
 
         this.#transport.subscribe(channels);
+
+        await Promise.all([this.#instrumentReady, this.#orderBookReady]);
     }
 
     async disconnect(): Promise<void> {
@@ -81,81 +89,11 @@ export class BitMex extends BaseCore {
         this.#instruments.clear();
         this.#instrumentEntities.clear();
         this.#assetEntities.clear();
+        this.#orderBookLevels.clear();
     }
 
-    async getInstruments(): Promise<Instrument[]> {
-        await this.#instrumentReady;
-
-        const instruments: Instrument[] = [];
-
-        this.#instrumentEntities.clear();
-
-        for (const item of this.#instruments.values()) {
-            const baseAsset = this.#getOrCreateAsset(item.underlying || item.rootSymbol || '');
-            const quoteAsset = this.#getOrCreateAsset(item.quoteCurrency || item.settlCurrency || '');
-            const inst = new Instrument(item.symbol, { baseAsset, quoteAsset } as Omit<Instrument, 'symbol'>);
-
-            instruments.push(inst);
-            this.#instrumentEntities.set(inst.symbol, inst);
-        }
-
-        return instruments;
-    }
-
-    async getOrders(instrument: Instrument): Promise<Order[]> {
-        if (!this.#transport.isConnected()) throw new Error('WebSocket not connected');
-
-        const channel = `orderBook10:${instrument.symbol}`;
-
-        this.#transport.send({ op: 'subscribe', args: [channel] });
-
-        return new Promise<Order[]>((resolve, reject) => {
-            const handleMessage = (event: MessageEvent) => {
-                try {
-                    const text = typeof event.data === 'string' ? event.data : '';
-                    const message = JSON.parse(text);
-
-                    if (message.table === 'orderBook10' && Array.isArray(message.data)) {
-                        const row = message.data.find((d: any) => d.symbol === instrument.symbol);
-
-                        if (!row) return;
-
-                        this.#transport.removeEventListener('message', handleMessage);
-                        this.#transport.send({ op: 'unsubscribe', args: [channel] });
-
-                        const orders: Order[] = [];
-
-                        if (row.bids?.length) {
-                            orders.push(
-                                new Order('bid', {
-                                    instrument,
-                                    price: row.bids[0][0],
-                                    size: row.bids[0][1],
-                                }),
-                            );
-                        }
-
-                        if (row.asks?.length) {
-                            orders.push(
-                                new Order('ask', {
-                                    instrument,
-                                    price: row.asks[0][0],
-                                    size: -row.asks[0][1],
-                                }),
-                            );
-                        }
-
-                        resolve(orders);
-                    }
-                } catch (err) {
-                    this.#transport.removeEventListener('message', handleMessage);
-                    reject(err);
-                }
-            };
-
-            this.#transport.addEventListener('message', handleMessage);
-            this.#transport.addEventListener('error', reject as any);
-        });
+    get instruments(): Instrument[] {
+        return [...this.#instrumentEntities.values()];
     }
 
     #getOrCreateAsset(symbol: string): Asset {
@@ -218,8 +156,60 @@ export class BitMex extends BaseCore {
         // noop
     };
 
-    #handleOrderBookL2Message = (_message: OrderBookL2Message) => {
-        // noop
+    #handleOrderBookL2Message = (message: OrderBookL2Message) => {
+        const grouped: Record<string, typeof message.data> = {};
+
+        for (const row of message.data) {
+            (grouped[row.symbol] ??= []).push(row);
+        }
+
+        for (const [symbol, rows] of Object.entries(grouped)) {
+            let book = this.#orderBookLevels.get(symbol);
+
+            if (message.action === 'partial') {
+                book = new Map();
+                this.#orderBookLevels.set(symbol, book);
+            } else {
+                if (!book) {
+                    book = new Map();
+                    this.#orderBookLevels.set(symbol, book);
+                }
+            }
+
+            switch (message.action) {
+                case 'partial':
+                case 'insert':
+                    for (const r of rows) {
+                        book!.set(r.id, { side: r.side, price: r.price, size: r.size });
+                    }
+                    break;
+                case 'update':
+                    for (const r of rows) {
+                        const level = book!.get(r.id);
+                        if (level) {
+                            level.size = r.size ?? level.size;
+                            level.price = r.price ?? level.price;
+                            level.side = r.side ?? level.side;
+                        } else {
+                            book!.set(r.id, { side: r.side, price: r.price, size: r.size });
+                        }
+                    }
+                    break;
+                case 'delete':
+                    for (const r of rows) {
+                        book!.delete(r.id);
+                    }
+                    break;
+                default:
+                    break;
+            }
+
+            this.#updateInstrumentOrderBook(symbol);
+        }
+
+        if (message.action === 'partial') {
+            this.#resolveOrderBookReady?.();
+        }
     };
 
     #handleSettlementMessage = (_message: SettlementMessage) => {
@@ -254,9 +244,17 @@ export class BitMex extends BaseCore {
         switch (message.action) {
             case 'partial':
                 this.#instruments.clear();
+                this.#instrumentEntities.clear();
 
                 for (const d of message.data as BitMexInstrument[]) {
                     this.#instruments.set(d.symbol, { ...d });
+
+                    const baseAsset = this.#getOrCreateAsset(d.underlying || d.rootSymbol || '');
+                    const quoteAsset = this.#getOrCreateAsset(d.quoteCurrency || d.settlCurrency || '');
+                    const inst = new Instrument(d.symbol, { baseAsset, quoteAsset } as Omit<Instrument, 'symbol'>);
+
+                    this.#instrumentEntities.set(inst.symbol, inst);
+                    this.#updateInstrumentOrderBook(d.symbol);
                 }
 
                 this.#resolveInstrumentReady?.();
@@ -264,12 +262,19 @@ export class BitMex extends BaseCore {
             case 'insert':
                 for (const item of message.data as BitMexInstrument[]) {
                     this.#instruments.set(item.symbol, { ...item });
+                    const baseAsset = this.#getOrCreateAsset(item.underlying || item.rootSymbol || '');
+                    const quoteAsset = this.#getOrCreateAsset(item.quoteCurrency || item.settlCurrency || '');
+                    const inst = new Instrument(item.symbol, { baseAsset, quoteAsset } as Omit<Instrument, 'symbol'>);
+                    this.#instrumentEntities.set(inst.symbol, inst);
+                    this.#updateInstrumentOrderBook(item.symbol);
                 }
 
                 break;
             case 'delete':
                 for (const item of message.data as BitMexInstrument[]) {
                     this.#instruments.delete(item.symbol);
+                    this.#instrumentEntities.delete(item.symbol);
+                    this.#orderBookLevels.delete(item.symbol);
                 }
 
                 break;
@@ -282,6 +287,22 @@ export class BitMex extends BaseCore {
                     } else {
                         this.#instruments.set(item.symbol, { ...item });
                     }
+
+                    const inst = this.#instrumentEntities.get(item.symbol);
+                    if (inst) {
+                        if (item.underlying || item.rootSymbol) {
+                            inst.baseAsset = this.#getOrCreateAsset(item.underlying || item.rootSymbol || '');
+                        }
+                        if (item.quoteCurrency || item.settlCurrency) {
+                            inst.quoteAsset = this.#getOrCreateAsset(item.quoteCurrency || item.settlCurrency || '');
+                        }
+                    } else {
+                        const baseAsset = this.#getOrCreateAsset(item.underlying || item.rootSymbol || '');
+                        const quoteAsset = this.#getOrCreateAsset(item.quoteCurrency || item.settlCurrency || '');
+                        const newInst = new Instrument(item.symbol, { baseAsset, quoteAsset } as Omit<Instrument, 'symbol'>);
+                        this.#instrumentEntities.set(newInst.symbol, newInst);
+                        this.#updateInstrumentOrderBook(item.symbol);
+                    }
                 }
 
                 break;
@@ -289,6 +310,58 @@ export class BitMex extends BaseCore {
                 break;
         }
     };
+
+    #updateInstrumentOrderBook(symbol: string) {
+        const instrument = this.#instrumentEntities.get(symbol);
+        const levels = this.#orderBookLevels.get(symbol);
+
+        if (!instrument || !levels) return;
+
+        const bids: { price: number; size: number }[] = [];
+        const asks: { price: number; size: number }[] = [];
+
+        for (const level of levels.values()) {
+            if (level.side === 'Buy') {
+                bids.push({ price: level.price, size: level.size });
+            } else {
+                asks.push({ price: level.price, size: -level.size });
+            }
+        }
+
+        bids.sort((a, b) => b.price - a.price);
+        asks.sort((a, b) => a.price - b.price);
+
+        instrument.orderBook.bids = bids;
+        instrument.orderBook.asks = asks;
+
+        instrument.orders = [];
+
+        if (bids.length) {
+            instrument.bid = bids[0].price;
+            instrument.orders.push(
+                new Order('bid', {
+                    instrument,
+                    price: bids[0].price,
+                    size: bids[0].size,
+                }),
+            );
+        } else {
+            instrument.bid = NaN;
+        }
+
+        if (asks.length) {
+            instrument.ask = asks[0].price;
+            instrument.orders.push(
+                new Order('ask', {
+                    instrument,
+                    price: asks[0].price,
+                    size: asks[0].size,
+                }),
+            );
+        } else {
+            instrument.ask = NaN;
+        }
+    }
 
     #isWelcomeMessage(message: any): message is WelcomeMessage {
         return typeof message?.info === 'string' && 'version' in message;


### PR DESCRIPTION
## Summary
- eliminate `getInstruments`/`getOrders` methods in favor of automatic entity management
- build instruments and orders from incoming BitMex messages and wait for initialization on connect
- expose core instruments through a property and update ExchangeHub accordingly

## Testing
- `npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68c57cf17d8c83208ef2178dc0bc5759