### PR TITLE
style: use two spaces in YAML files

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,30 +1,30 @@
 name: Publish
 
 on:
-    push:
-        branches: [main]
+  push:
+    branches: [main]
 
 jobs:
-    publish:
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v4
-            - uses: actions/setup-node@v4
-              with:
-                  node-version: 20
-                  registry-url: https://registry.npmjs.org
-            - id: versions
-              run: |
-                  PACKAGE_NAME=$(node -p "require('./package.json').name")
-                  PACKAGE_VERSION=$(node -p "require('./package.json').version")
-                  PUBLISHED_VERSION=$(npm view "$PACKAGE_NAME" version || echo "0.0.0")
-                  echo "packageVersion=$PACKAGE_VERSION" >> $GITHUB_OUTPUT
-                  echo "publishedVersion=$PUBLISHED_VERSION" >> $GITHUB_OUTPUT
-            - name: Publish
-              if: steps.versions.outputs.packageVersion != steps.versions.outputs.publishedVersion
-              env:
-                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-              run: |
-                  npm ci
-                  npm run build
-                  npm publish --access public
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org
+      - id: versions
+        run: |
+          PACKAGE_NAME=$(node -p "require('./package.json').name")
+          PACKAGE_VERSION=$(node -p "require('./package.json').version")
+          PUBLISHED_VERSION=$(npm view "$PACKAGE_NAME" version || echo "0.0.0")
+          echo "packageVersion=$PACKAGE_VERSION" >> $GITHUB_OUTPUT
+          echo "publishedVersion=$PUBLISHED_VERSION" >> $GITHUB_OUTPUT
+      - name: Publish
+        if: steps.versions.outputs.packageVersion != steps.versions.outputs.publishedVersion
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          npm ci
+          npm run build
+          npm publish --access public

--- a/.prettierrc
+++ b/.prettierrc
@@ -6,5 +6,13 @@
     "endOfLine": "lf",
     "semi": true,
     "arrowParens": "avoid",
-    "bracketSpacing": true
+    "bracketSpacing": true,
+    "overrides": [
+        {
+            "files": ["*.yml", "*.yaml"],
+            "options": {
+                "tabWidth": 2
+            }
+        }
+    ]
 }


### PR DESCRIPTION
## Summary
- enforce 2-space indentation for YAML files via Prettier overrides
- adjust publish workflow YAML to use 2-space indentation

## Testing
- `npm run lint`
- `npm test -- --passWithNoTests`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_68c590d72de083209257c37a1ce004e4