### PR TITLE
feat: enforce blank line after super calls

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,6 +4,14 @@ const prettierPlugin = require('eslint-plugin-prettier');
 const importPlugin = require('eslint-plugin-import');
 const unusedImportsPlugin = require('eslint-plugin-unused-imports');
 
+const newlineAfterSuperRule = require('./eslint/rules/newline-after-super');
+
+const newlineAfterSuperPlugin = {
+    rules: {
+        'newline-after-super': newlineAfterSuperRule,
+    },
+};
+
 module.exports = [
     {
         ignores: ['dist/**', 'node_modules/**'],
@@ -23,6 +31,7 @@ module.exports = [
             prettier: prettierPlugin,
             import: importPlugin,
             'unused-imports': unusedImportsPlugin,
+            'newline-after-super': newlineAfterSuperPlugin,
         },
         rules: {
             ...js.configs.recommended.rules,
@@ -66,6 +75,7 @@ module.exports = [
                 'error',
                 { enforce: [{ blankLine: 'always', prev: 'method', next: 'method' }] },
             ],
+            'newline-after-super/newline-after-super': 'error',
             'prettier/prettier': 'error',
             'padding-line-between-statements': [
                 'error',
@@ -105,6 +115,7 @@ module.exports = [
             prettier: prettierPlugin,
             import: importPlugin,
             'unused-imports': unusedImportsPlugin,
+            'newline-after-super': newlineAfterSuperPlugin,
         },
         rules: {
             ...js.configs.recommended.rules,
@@ -157,6 +168,7 @@ module.exports = [
                 'error',
                 { enforce: [{ blankLine: 'always', prev: 'method', next: 'method' }] },
             ],
+            'newline-after-super/newline-after-super': 'error',
             '@typescript-eslint/consistent-type-imports': 'error',
             'prettier/prettier': 'error',
             'padding-line-between-statements': [

--- a/eslint/rules/newline-after-super.js
+++ b/eslint/rules/newline-after-super.js
@@ -1,0 +1,55 @@
+module.exports = {
+    meta: {
+        type: 'layout',
+        docs: {
+            description: 'require empty line after super() call in constructor',
+        },
+        fixable: 'whitespace',
+        schema: [],
+    },
+    create(context) {
+        const sourceCode = context.getSourceCode();
+
+        return {
+            MethodDefinition(node) {
+                if (node.kind !== 'constructor') return;
+
+                const body = node.value && node.value.body;
+
+                if (!body) return;
+
+                const statements = body.body;
+
+                if (statements.length < 2) return;
+
+                const firstStatement = statements[0];
+
+                if (
+                    firstStatement.type !== 'ExpressionStatement' ||
+                    firstStatement.expression.type !== 'CallExpression' ||
+                    firstStatement.expression.callee.type !== 'Super'
+                ) {
+                    return;
+                }
+
+                const lastToken = sourceCode.getLastToken(firstStatement);
+                const nextToken = sourceCode.getTokenAfter(lastToken, { includeComments: true });
+
+                if (!nextToken) return;
+
+                const textBetween = sourceCode.text.slice(lastToken.range[1], nextToken.range[0]);
+                const lineBreaks = textBetween.match(/\n/g);
+
+                if (!lineBreaks || lineBreaks.length < 2) {
+                    context.report({
+                        node: firstStatement,
+                        message: 'Expected empty line after super() call.',
+                        fix(fixer) {
+                            return fixer.insertTextAfter(lastToken, '\n');
+                        },
+                    });
+                }
+            },
+        };
+    },
+};

--- a/src/entities/createTrade.ts
+++ b/src/entities/createTrade.ts
@@ -28,6 +28,7 @@ export function createTrade<ExName extends ExchangeName>(eh: ExchangeHub<ExName>
             },
         ) {
             super();
+
             this.id = id;
             this.instrument = instrument;
             this.price = price;


### PR DESCRIPTION
## Summary
- add custom ESLint rule requiring a blank line after `super()` in constructors
- apply rule across codebase and integrate into ESLint config

## Testing
- `npm test` *(fails: No tests found)*
- `npm run lint`
- `npm run type-check`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_68c5a7d52d8c8320a65b296c8b215161