### PR TITLE
Add stub BitMex table message handlers

### DIFF
--- a/src/cores/BaseCore.ts
+++ b/src/cores/BaseCore.ts
@@ -7,7 +7,7 @@ export class BaseCore<ExName extends ExchangeName> {
     #isTest = false;
     #apiKey?: ApiKey;
     #apiSec?: ApiSec;
-    #instruments: Instrument<ExName>;
+    #instruments!: Instrument<ExName>;
 
     constructor(shell: ExchangeHub<ExName>, settings: Settings) {
         const { isTest, apiKey, apiSec } = settings;

--- a/src/cores/bitmex/tableMessageHandlers/execution.ts
+++ b/src/cores/bitmex/tableMessageHandlers/execution.ts
@@ -1,0 +1,20 @@
+import type { BitMex } from '..';
+import type { BitMexExecution } from '../types';
+
+export const execution = {
+    partial(_core: BitMex, _data: BitMexExecution[]) {
+        throw 'not implemented';
+    },
+
+    insert(_core: BitMex, _data: BitMexExecution[]) {
+        throw 'not implemented';
+    },
+
+    update(_core: BitMex, _data: BitMexExecution[]) {
+        throw 'not implemented';
+    },
+
+    delete(_core: BitMex, _data: BitMexExecution[]) {
+        throw 'not implemented';
+    },
+};

--- a/src/cores/bitmex/tableMessageHandlers/funding.ts
+++ b/src/cores/bitmex/tableMessageHandlers/funding.ts
@@ -1,0 +1,20 @@
+import type { BitMex } from '..';
+import type { BitMexFunding } from '../types';
+
+export const funding = {
+    partial(_core: BitMex, _data: BitMexFunding[]) {
+        throw 'not implemented';
+    },
+
+    insert(_core: BitMex, _data: BitMexFunding[]) {
+        throw 'not implemented';
+    },
+
+    update(_core: BitMex, _data: BitMexFunding[]) {
+        throw 'not implemented';
+    },
+
+    delete(_core: BitMex, _data: BitMexFunding[]) {
+        throw 'not implemented';
+    },
+};

--- a/src/cores/bitmex/tableMessageHandlers/index.ts
+++ b/src/cores/bitmex/tableMessageHandlers/index.ts
@@ -1,9 +1,33 @@
 import { instrument } from './instrument';
+import { trade } from './trade';
+import { funding } from './funding';
+import { liquidation } from './liquidation';
+import { orderBookL2 } from './orderBookL2';
+import { settlement } from './settlement';
+import { execution } from './execution';
+import { order } from './order';
+import { margin } from './margin';
+import { position } from './position';
+import { transact } from './transact';
+import { wallet } from './wallet';
 
 import type { BitMex } from '..';
 import type { BitMexChannel, BitMexChannelMessageAction, BitMexChannelMessageMap } from '../types';
 
-export const tableMessageHandlers = { instrument } satisfies {
+export const tableMessageHandlers = {
+    instrument,
+    trade,
+    funding,
+    liquidation,
+    orderBookL2,
+    settlement,
+    execution,
+    order,
+    margin,
+    position,
+    transact,
+    wallet,
+} satisfies {
     [Channel in BitMexChannel]: {
         [Action in BitMexChannelMessageAction]: (core: BitMex, data: BitMexChannelMessageMap[Channel][]) => void;
     };

--- a/src/cores/bitmex/tableMessageHandlers/index.ts
+++ b/src/cores/bitmex/tableMessageHandlers/index.ts
@@ -3,8 +3,8 @@ import { instrument } from './instrument';
 import type { BitMex } from '..';
 import type { BitMexChannel, BitMexChannelMessageAction, BitMexChannelMessageMap } from '../types';
 
-export const tableMessageHandlers: {
+export const tableMessageHandlers = { instrument } satisfies {
     [Channel in BitMexChannel]: {
         [Action in BitMexChannelMessageAction]: (core: BitMex, data: BitMexChannelMessageMap[Channel][]) => void;
     };
-} = { instrument };
+};

--- a/src/cores/bitmex/tableMessageHandlers/instrument.ts
+++ b/src/cores/bitmex/tableMessageHandlers/instrument.ts
@@ -2,19 +2,19 @@ import type { BitMex } from '..';
 import type { BitMexInstrument } from '../types';
 
 export const instrument = {
-    partial(core: BitMex, data: BitMexInstrument[]) {
+    partial(_core: BitMex, _data: BitMexInstrument[]) {
         throw 'not implemented';
     },
 
-    insert(core: BitMex, data: BitMexInstrument[]) {
+    insert(_core: BitMex, _data: BitMexInstrument[]) {
         throw 'not implemented';
     },
 
-    update(core: BitMex, data: BitMexInstrument[]) {
+    update(_core: BitMex, _data: BitMexInstrument[]) {
         throw 'not implemented';
     },
 
-    delete(core: BitMex, data: BitMexInstrument[]) {
+    delete(_core: BitMex, _data: BitMexInstrument[]) {
         throw 'not implemented';
     },
 };

--- a/src/cores/bitmex/tableMessageHandlers/liquidation.ts
+++ b/src/cores/bitmex/tableMessageHandlers/liquidation.ts
@@ -1,0 +1,20 @@
+import type { BitMex } from '..';
+import type { BitMexLiquidation } from '../types';
+
+export const liquidation = {
+    partial(_core: BitMex, _data: BitMexLiquidation[]) {
+        throw 'not implemented';
+    },
+
+    insert(_core: BitMex, _data: BitMexLiquidation[]) {
+        throw 'not implemented';
+    },
+
+    update(_core: BitMex, _data: BitMexLiquidation[]) {
+        throw 'not implemented';
+    },
+
+    delete(_core: BitMex, _data: BitMexLiquidation[]) {
+        throw 'not implemented';
+    },
+};

--- a/src/cores/bitmex/tableMessageHandlers/margin.ts
+++ b/src/cores/bitmex/tableMessageHandlers/margin.ts
@@ -1,0 +1,20 @@
+import type { BitMex } from '..';
+import type { BitMexMargin } from '../types';
+
+export const margin = {
+    partial(_core: BitMex, _data: BitMexMargin[]) {
+        throw 'not implemented';
+    },
+
+    insert(_core: BitMex, _data: BitMexMargin[]) {
+        throw 'not implemented';
+    },
+
+    update(_core: BitMex, _data: BitMexMargin[]) {
+        throw 'not implemented';
+    },
+
+    delete(_core: BitMex, _data: BitMexMargin[]) {
+        throw 'not implemented';
+    },
+};

--- a/src/cores/bitmex/tableMessageHandlers/order.ts
+++ b/src/cores/bitmex/tableMessageHandlers/order.ts
@@ -1,0 +1,20 @@
+import type { BitMex } from '..';
+import type { BitMexOrder } from '../types';
+
+export const order = {
+    partial(_core: BitMex, _data: BitMexOrder[]) {
+        throw 'not implemented';
+    },
+
+    insert(_core: BitMex, _data: BitMexOrder[]) {
+        throw 'not implemented';
+    },
+
+    update(_core: BitMex, _data: BitMexOrder[]) {
+        throw 'not implemented';
+    },
+
+    delete(_core: BitMex, _data: BitMexOrder[]) {
+        throw 'not implemented';
+    },
+};

--- a/src/cores/bitmex/tableMessageHandlers/orderBookL2.ts
+++ b/src/cores/bitmex/tableMessageHandlers/orderBookL2.ts
@@ -1,0 +1,20 @@
+import type { BitMex } from '..';
+import type { BitMexOrderBookL2 } from '../types';
+
+export const orderBookL2 = {
+    partial(_core: BitMex, _data: BitMexOrderBookL2[]) {
+        throw 'not implemented';
+    },
+
+    insert(_core: BitMex, _data: BitMexOrderBookL2[]) {
+        throw 'not implemented';
+    },
+
+    update(_core: BitMex, _data: BitMexOrderBookL2[]) {
+        throw 'not implemented';
+    },
+
+    delete(_core: BitMex, _data: BitMexOrderBookL2[]) {
+        throw 'not implemented';
+    },
+};

--- a/src/cores/bitmex/tableMessageHandlers/position.ts
+++ b/src/cores/bitmex/tableMessageHandlers/position.ts
@@ -1,0 +1,20 @@
+import type { BitMex } from '..';
+import type { BitMexPosition } from '../types';
+
+export const position = {
+    partial(_core: BitMex, _data: BitMexPosition[]) {
+        throw 'not implemented';
+    },
+
+    insert(_core: BitMex, _data: BitMexPosition[]) {
+        throw 'not implemented';
+    },
+
+    update(_core: BitMex, _data: BitMexPosition[]) {
+        throw 'not implemented';
+    },
+
+    delete(_core: BitMex, _data: BitMexPosition[]) {
+        throw 'not implemented';
+    },
+};

--- a/src/cores/bitmex/tableMessageHandlers/settlement.ts
+++ b/src/cores/bitmex/tableMessageHandlers/settlement.ts
@@ -1,0 +1,20 @@
+import type { BitMex } from '..';
+import type { BitMexSettlement } from '../types';
+
+export const settlement = {
+    partial(_core: BitMex, _data: BitMexSettlement[]) {
+        throw 'not implemented';
+    },
+
+    insert(_core: BitMex, _data: BitMexSettlement[]) {
+        throw 'not implemented';
+    },
+
+    update(_core: BitMex, _data: BitMexSettlement[]) {
+        throw 'not implemented';
+    },
+
+    delete(_core: BitMex, _data: BitMexSettlement[]) {
+        throw 'not implemented';
+    },
+};

--- a/src/cores/bitmex/tableMessageHandlers/trade.ts
+++ b/src/cores/bitmex/tableMessageHandlers/trade.ts
@@ -1,0 +1,20 @@
+import type { BitMex } from '..';
+import type { BitMexTrade } from '../types';
+
+export const trade = {
+    partial(_core: BitMex, _data: BitMexTrade[]) {
+        throw 'not implemented';
+    },
+
+    insert(_core: BitMex, _data: BitMexTrade[]) {
+        throw 'not implemented';
+    },
+
+    update(_core: BitMex, _data: BitMexTrade[]) {
+        throw 'not implemented';
+    },
+
+    delete(_core: BitMex, _data: BitMexTrade[]) {
+        throw 'not implemented';
+    },
+};

--- a/src/cores/bitmex/tableMessageHandlers/transact.ts
+++ b/src/cores/bitmex/tableMessageHandlers/transact.ts
@@ -1,0 +1,20 @@
+import type { BitMex } from '..';
+import type { BitMexTransact } from '../types';
+
+export const transact = {
+    partial(_core: BitMex, _data: BitMexTransact[]) {
+        throw 'not implemented';
+    },
+
+    insert(_core: BitMex, _data: BitMexTransact[]) {
+        throw 'not implemented';
+    },
+
+    update(_core: BitMex, _data: BitMexTransact[]) {
+        throw 'not implemented';
+    },
+
+    delete(_core: BitMex, _data: BitMexTransact[]) {
+        throw 'not implemented';
+    },
+};

--- a/src/cores/bitmex/tableMessageHandlers/wallet.ts
+++ b/src/cores/bitmex/tableMessageHandlers/wallet.ts
@@ -1,0 +1,20 @@
+import type { BitMex } from '..';
+import type { BitMexWallet } from '../types';
+
+export const wallet = {
+    partial(_core: BitMex, _data: BitMexWallet[]) {
+        throw 'not implemented';
+    },
+
+    insert(_core: BitMex, _data: BitMexWallet[]) {
+        throw 'not implemented';
+    },
+
+    update(_core: BitMex, _data: BitMexWallet[]) {
+        throw 'not implemented';
+    },
+
+    delete(_core: BitMex, _data: BitMexWallet[]) {
+        throw 'not implemented';
+    },
+};

--- a/src/cores/bitmex/transport.ts
+++ b/src/cores/bitmex/transport.ts
@@ -45,10 +45,10 @@ export class BitMexTransport {
 
         const { table, action, data } = message;
 
-        tableMessageHandlers[table][action](this.#core, data);
+        tableMessageHandlers[table][action](this.#core, data as any);
     }
 
-    #handleSubscribeMessage(message: BitMexSubscribeMessage) {
+    #handleSubscribeMessage(_message: BitMexSubscribeMessage) {
         throw 'not implemented';
     }
 

--- a/src/entities/createInstrument.ts
+++ b/src/entities/createInstrument.ts
@@ -17,7 +17,7 @@ export function createInstrument<ExName extends ExchangeName>(eh: ExchangeHub<Ex
         trades: Trade<ExName>[] = [];
         bid = NaN;
         ask = NaN;
-        orderBook = new (createOrderBook(eh, Entity))(this);
+        orderBook: InstanceType<ReturnType<typeof createOrderBook<ExName>>> = new (createOrderBook(eh, Entity))(this);
         orders: Order<ExName>[] = [];
 
         constructor(symbol: string, { baseAsset, quoteAsset }: Omit<Instrument, 'symbol'>) {


### PR DESCRIPTION
## Summary
- add placeholder handlers for all BitMex table messages
- wire up new handlers in the table message dispatcher
- fix type-check and lint issues in core utilities

## Testing
- `npm test -- --passWithNoTests`
- `npm run lint`
- `npm run format`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68c673d5ad1c8320a77713f6e15f2c98