### PR TITLE
feat: add BitMex table message handlers

### DIFF
--- a/src/cores/bitmex/tableMessageHandlers/execution.ts
+++ b/src/cores/bitmex/tableMessageHandlers/execution.ts
@@ -1,0 +1,20 @@
+import type { BitMex } from '..';
+import type { BitMexExecution } from '../types';
+
+export const execution = {
+    partial(core: BitMex, data: BitMexExecution[]) {
+        throw 'not implemented';
+    },
+
+    insert(core: BitMex, data: BitMexExecution[]) {
+        throw 'not implemented';
+    },
+
+    update(core: BitMex, data: BitMexExecution[]) {
+        throw 'not implemented';
+    },
+
+    delete(core: BitMex, data: BitMexExecution[]) {
+        throw 'not implemented';
+    },
+};

--- a/src/cores/bitmex/tableMessageHandlers/funding.ts
+++ b/src/cores/bitmex/tableMessageHandlers/funding.ts
@@ -1,0 +1,20 @@
+import type { BitMex } from '..';
+import type { BitMexFunding } from '../types';
+
+export const funding = {
+    partial(core: BitMex, data: BitMexFunding[]) {
+        throw 'not implemented';
+    },
+
+    insert(core: BitMex, data: BitMexFunding[]) {
+        throw 'not implemented';
+    },
+
+    update(core: BitMex, data: BitMexFunding[]) {
+        throw 'not implemented';
+    },
+
+    delete(core: BitMex, data: BitMexFunding[]) {
+        throw 'not implemented';
+    },
+};

--- a/src/cores/bitmex/tableMessageHandlers/index.ts
+++ b/src/cores/bitmex/tableMessageHandlers/index.ts
@@ -1,4 +1,15 @@
 import { instrument } from './instrument';
+import { trade } from './trade';
+import { funding } from './funding';
+import { liquidation } from './liquidation';
+import { orderBookL2 } from './orderBookL2';
+import { settlement } from './settlement';
+import { execution } from './execution';
+import { order } from './order';
+import { margin } from './margin';
+import { position } from './position';
+import { transact } from './transact';
+import { wallet } from './wallet';
 
 import type { BitMex } from '..';
 import type { BitMexChannel, BitMexChannelMessageAction, BitMexChannelMessageMap } from '../types';
@@ -7,4 +18,17 @@ export const tableMessageHandlers: {
     [Channel in BitMexChannel]: {
         [Action in BitMexChannelMessageAction]: (core: BitMex, data: BitMexChannelMessageMap[Channel][]) => void;
     };
-} = { instrument };
+} = {
+    instrument,
+    trade,
+    funding,
+    liquidation,
+    orderBookL2,
+    settlement,
+    execution,
+    order,
+    margin,
+    position,
+    transact,
+    wallet,
+};

--- a/src/cores/bitmex/tableMessageHandlers/liquidation.ts
+++ b/src/cores/bitmex/tableMessageHandlers/liquidation.ts
@@ -1,0 +1,20 @@
+import type { BitMex } from '..';
+import type { BitMexLiquidation } from '../types';
+
+export const liquidation = {
+    partial(core: BitMex, data: BitMexLiquidation[]) {
+        throw 'not implemented';
+    },
+
+    insert(core: BitMex, data: BitMexLiquidation[]) {
+        throw 'not implemented';
+    },
+
+    update(core: BitMex, data: BitMexLiquidation[]) {
+        throw 'not implemented';
+    },
+
+    delete(core: BitMex, data: BitMexLiquidation[]) {
+        throw 'not implemented';
+    },
+};

--- a/src/cores/bitmex/tableMessageHandlers/margin.ts
+++ b/src/cores/bitmex/tableMessageHandlers/margin.ts
@@ -1,0 +1,20 @@
+import type { BitMex } from '..';
+import type { BitMexMargin } from '../types';
+
+export const margin = {
+    partial(core: BitMex, data: BitMexMargin[]) {
+        throw 'not implemented';
+    },
+
+    insert(core: BitMex, data: BitMexMargin[]) {
+        throw 'not implemented';
+    },
+
+    update(core: BitMex, data: BitMexMargin[]) {
+        throw 'not implemented';
+    },
+
+    delete(core: BitMex, data: BitMexMargin[]) {
+        throw 'not implemented';
+    },
+};

--- a/src/cores/bitmex/tableMessageHandlers/order.ts
+++ b/src/cores/bitmex/tableMessageHandlers/order.ts
@@ -1,0 +1,20 @@
+import type { BitMex } from '..';
+import type { BitMexOrder } from '../types';
+
+export const order = {
+    partial(core: BitMex, data: BitMexOrder[]) {
+        throw 'not implemented';
+    },
+
+    insert(core: BitMex, data: BitMexOrder[]) {
+        throw 'not implemented';
+    },
+
+    update(core: BitMex, data: BitMexOrder[]) {
+        throw 'not implemented';
+    },
+
+    delete(core: BitMex, data: BitMexOrder[]) {
+        throw 'not implemented';
+    },
+};

--- a/src/cores/bitmex/tableMessageHandlers/orderBookL2.ts
+++ b/src/cores/bitmex/tableMessageHandlers/orderBookL2.ts
@@ -1,0 +1,20 @@
+import type { BitMex } from '..';
+import type { BitMexOrderBookL2 } from '../types';
+
+export const orderBookL2 = {
+    partial(core: BitMex, data: BitMexOrderBookL2[]) {
+        throw 'not implemented';
+    },
+
+    insert(core: BitMex, data: BitMexOrderBookL2[]) {
+        throw 'not implemented';
+    },
+
+    update(core: BitMex, data: BitMexOrderBookL2[]) {
+        throw 'not implemented';
+    },
+
+    delete(core: BitMex, data: BitMexOrderBookL2[]) {
+        throw 'not implemented';
+    },
+};

--- a/src/cores/bitmex/tableMessageHandlers/position.ts
+++ b/src/cores/bitmex/tableMessageHandlers/position.ts
@@ -1,0 +1,20 @@
+import type { BitMex } from '..';
+import type { BitMexPosition } from '../types';
+
+export const position = {
+    partial(core: BitMex, data: BitMexPosition[]) {
+        throw 'not implemented';
+    },
+
+    insert(core: BitMex, data: BitMexPosition[]) {
+        throw 'not implemented';
+    },
+
+    update(core: BitMex, data: BitMexPosition[]) {
+        throw 'not implemented';
+    },
+
+    delete(core: BitMex, data: BitMexPosition[]) {
+        throw 'not implemented';
+    },
+};

--- a/src/cores/bitmex/tableMessageHandlers/settlement.ts
+++ b/src/cores/bitmex/tableMessageHandlers/settlement.ts
@@ -1,0 +1,20 @@
+import type { BitMex } from '..';
+import type { BitMexSettlement } from '../types';
+
+export const settlement = {
+    partial(core: BitMex, data: BitMexSettlement[]) {
+        throw 'not implemented';
+    },
+
+    insert(core: BitMex, data: BitMexSettlement[]) {
+        throw 'not implemented';
+    },
+
+    update(core: BitMex, data: BitMexSettlement[]) {
+        throw 'not implemented';
+    },
+
+    delete(core: BitMex, data: BitMexSettlement[]) {
+        throw 'not implemented';
+    },
+};

--- a/src/cores/bitmex/tableMessageHandlers/trade.ts
+++ b/src/cores/bitmex/tableMessageHandlers/trade.ts
@@ -1,0 +1,20 @@
+import type { BitMex } from '..';
+import type { BitMexTrade } from '../types';
+
+export const trade = {
+    partial(core: BitMex, data: BitMexTrade[]) {
+        throw 'not implemented';
+    },
+
+    insert(core: BitMex, data: BitMexTrade[]) {
+        throw 'not implemented';
+    },
+
+    update(core: BitMex, data: BitMexTrade[]) {
+        throw 'not implemented';
+    },
+
+    delete(core: BitMex, data: BitMexTrade[]) {
+        throw 'not implemented';
+    },
+};

--- a/src/cores/bitmex/tableMessageHandlers/transact.ts
+++ b/src/cores/bitmex/tableMessageHandlers/transact.ts
@@ -1,0 +1,20 @@
+import type { BitMex } from '..';
+import type { BitMexTransact } from '../types';
+
+export const transact = {
+    partial(core: BitMex, data: BitMexTransact[]) {
+        throw 'not implemented';
+    },
+
+    insert(core: BitMex, data: BitMexTransact[]) {
+        throw 'not implemented';
+    },
+
+    update(core: BitMex, data: BitMexTransact[]) {
+        throw 'not implemented';
+    },
+
+    delete(core: BitMex, data: BitMexTransact[]) {
+        throw 'not implemented';
+    },
+};

--- a/src/cores/bitmex/tableMessageHandlers/wallet.ts
+++ b/src/cores/bitmex/tableMessageHandlers/wallet.ts
@@ -1,0 +1,20 @@
+import type { BitMex } from '..';
+import type { BitMexWallet } from '../types';
+
+export const wallet = {
+    partial(core: BitMex, data: BitMexWallet[]) {
+        throw 'not implemented';
+    },
+
+    insert(core: BitMex, data: BitMexWallet[]) {
+        throw 'not implemented';
+    },
+
+    update(core: BitMex, data: BitMexWallet[]) {
+        throw 'not implemented';
+    },
+
+    delete(core: BitMex, data: BitMexWallet[]) {
+        throw 'not implemented';
+    },
+};


### PR DESCRIPTION
## Summary
- add placeholder handlers for all BitMex table message types
- expose handlers through tableMessageHandlers index

## Testing
- `npm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68c67887ae248320b7a02fbe3c6f4cfa