### PR TITLE
feat: add BitMex order methods

### DIFF
--- a/src/cores/bitmex/constants.ts
+++ b/src/cores/bitmex/constants.ts
@@ -1,11 +1,15 @@
-export const BITMEX_PUBLIC_CHANNELS = [
-    'instrument',
-    'trade',
-    'liquidation',
-    'orderBookL2',
-    'settlement',
-] as const;
+export const BITMEX_PUBLIC_CHANNELS = ['instrument', 'trade', 'liquidation', 'orderBookL2', 'settlement'] as const;
 
 export const BITMEX_PRIVATE_CHANNELS = ['execution', 'order', 'margin', 'position', 'transact', 'wallet'] as const;
 
 export const BITMEX_CHANNELS = [...BITMEX_PUBLIC_CHANNELS, ...BITMEX_PRIVATE_CHANNELS] as const;
+
+export const BITMEX_WS_ENDPOINTS = {
+    testnet: 'wss://testnet.bitmex.com/realtime',
+    mainnet: 'wss://www.bitmex.com/realtime',
+} as const;
+
+export const BITMEX_REST_ENDPOINTS = {
+    testnet: 'https://testnet.bitmex.com/api/v1',
+    mainnet: 'https://www.bitmex.com/api/v1',
+} as const;

--- a/src/cores/bitmex/transport.ts
+++ b/src/cores/bitmex/transport.ts
@@ -13,6 +13,8 @@ import type {
     BitMexChangeOrderRequest,
 } from './types';
 
+type BitMexRequestVerb = 'GET' | 'POST' | 'PUT' | 'DELETE';
+
 export class BitMexTransport {
     #core: BitMex;
     #wsEndpoint: string;
@@ -57,11 +59,11 @@ export class BitMexTransport {
         throw new Error('Unknown message');
     }
 
-    #handleWelcomeMessage(_message: BitMexWelcomeMessage) {
+    #handleWelcomeMessage(message: BitMexWelcomeMessage) {
         throw 'not implemented';
     }
 
-    #handleSubscribeMessage(_message: BitMexSubscribeMessage) {
+    #handleSubscribeMessage(message: BitMexSubscribeMessage) {
         throw 'not implemented';
     }
 
@@ -123,7 +125,7 @@ export class BitMexTransport {
         return this.#request('DELETE', path);
     }
 
-    async #request<T>(verb: string, path: string, body?: any): Promise<T> {
+    async #request<T>(verb: BitMexRequestVerb, path: string, body?: any): Promise<T> {
         if (!this.#apiKey || !this.#apiSec) {
             throw new Error('API credentials required');
         }

--- a/src/cores/bitmex/transport.ts
+++ b/src/cores/bitmex/transport.ts
@@ -132,8 +132,9 @@ export class BitMexTransport {
 
         const expires = Math.round(Date.now() / 1000) + 60;
         const bodyText = body ? JSON.stringify(body) : '';
+        const signedPath = `/api/v1${path}`;
         const signature = createHmac('sha256', this.#apiSec)
-            .update(`${verb}${path}${expires}${bodyText}`)
+            .update(`${verb}${signedPath}${expires}${bodyText}`)
             .digest('hex');
 
         const headers: Record<string, string> = {

--- a/src/cores/bitmex/types.ts
+++ b/src/cores/bitmex/types.ts
@@ -237,17 +237,35 @@ export type BitMexWallet = {
 
 export type BitMexPlaceOrderRequest = {
     symbol: string;
-    side: BitMexSide;
-    orderQty: number;
+    side?: BitMexSide;
+    simpleOrderQty?: number;
+    orderQty?: number;
     price?: number;
+    displayQty?: number;
+    stopPx?: number;
     clOrdID?: string;
+    clOrdLinkID?: string;
+    pegOffsetValue?: number;
+    pegPriceType?: string;
+    ordType?: string;
+    timeInForce?: string;
+    execInst?: string;
+    contingencyType?: string;
+    text?: string;
 };
 
 export type BitMexChangeOrderRequest = {
-    orderID: string;
-    price?: number;
-    orderQty?: number;
+    orderID?: string;
+    origClOrdID?: string;
     clOrdID?: string;
+    simpleOrderQty?: number;
+    orderQty?: number;
+    simpleLeavesQty?: number;
+    leavesQty?: number;
+    price?: number;
+    stopPx?: number;
+    pegOffsetValue?: number;
+    text?: string;
 };
 
 export type BitMexRequestVerb = 'GET' | 'POST' | 'PUT' | 'DELETE';

--- a/src/cores/bitmex/types.ts
+++ b/src/cores/bitmex/types.ts
@@ -249,3 +249,5 @@ export type BitMexChangeOrderRequest = {
     orderQty?: number;
     clOrdID?: string;
 };
+
+export type BitMexRequestVerb = 'GET' | 'POST' | 'PUT' | 'DELETE';

--- a/src/cores/bitmex/types.ts
+++ b/src/cores/bitmex/types.ts
@@ -232,3 +232,18 @@ export type BitMexWallet = {
     availableMargin?: number;
     walletBalance?: number;
 };
+
+export type BitMexPlaceOrderRequest = {
+    symbol: string;
+    side: 'Buy' | 'Sell';
+    orderQty: number;
+    price?: number;
+    clOrdID?: string;
+};
+
+export type BitMexChangeOrderRequest = {
+    orderID: string;
+    price?: number;
+    orderQty?: number;
+    clOrdID?: string;
+};

--- a/src/cores/bitmex/types.ts
+++ b/src/cores/bitmex/types.ts
@@ -22,6 +22,18 @@ export type BitMexChannel = (typeof BITMEX_CHANNELS)[number];
 
 export type BitMexSide = 'Buy' | 'Sell';
 
+export type BitMexOrderType =
+    | 'Market'
+    | 'Limit'
+    | 'Stop'
+    | 'StopLimit'
+    | 'MarketIfTouched'
+    | 'LimitIfTouched'
+    | 'MarketWithLeftoverAsLimit'
+    | 'LimitWithLeftoverAsMarket'
+    | 'StopMarket'
+    | 'Pegged';
+
 export type BitMexChannelMessageAction = 'partial' | 'insert' | 'update' | 'delete';
 
 export type BitMexChannelMessage<Channel extends BitMexChannel> = {
@@ -247,7 +259,7 @@ export type BitMexPlaceOrderRequest = {
     clOrdLinkID?: string;
     pegOffsetValue?: number;
     pegPriceType?: string;
-    ordType?: string;
+    ordType?: BitMexOrderType;
     timeInForce?: string;
     execInst?: string;
     contingencyType?: string;

--- a/src/cores/bitmex/types.ts
+++ b/src/cores/bitmex/types.ts
@@ -20,6 +20,8 @@ export type BitMexPublicChannel = (typeof BITMEX_PUBLIC_CHANNELS)[number];
 export type BitMexPrivateChannel = (typeof BITMEX_PRIVATE_CHANNELS)[number];
 export type BitMexChannel = (typeof BITMEX_CHANNELS)[number];
 
+export type BitMexSide = 'Buy' | 'Sell';
+
 export type BitMexChannelMessageAction = 'partial' | 'insert' | 'update' | 'delete';
 
 export type BitMexChannelMessage<Channel extends BitMexChannel> = {
@@ -148,7 +150,7 @@ export type BitMexInstrument = {
 export type BitMexTrade = {
     trdMatchID: string;
     symbol: string;
-    side: 'Buy' | 'Sell';
+    side: BitMexSide;
     size: number;
     price: number;
     timestamp: string;
@@ -157,7 +159,7 @@ export type BitMexTrade = {
 export type BitMexLiquidation = {
     orderID: string;
     symbol: string;
-    side: 'Buy' | 'Sell';
+    side: BitMexSide;
     price: number;
     leavesQty: number;
 };
@@ -165,7 +167,7 @@ export type BitMexLiquidation = {
 export type BitMexOrderBookL2 = {
     symbol: string;
     id: number;
-    side: 'Buy' | 'Sell';
+    side: BitMexSide;
     size?: number;
     price?: number;
 };
@@ -182,7 +184,7 @@ export type BitMexExecution = {
     orderID: string;
     clOrdID?: string;
     symbol: string;
-    side?: 'Buy' | 'Sell';
+    side?: BitMexSide;
     price?: number;
     size?: number;
 };
@@ -191,7 +193,7 @@ export type BitMexOrder = {
     orderID: string;
     clOrdID?: string;
     symbol: string;
-    side?: 'Buy' | 'Sell';
+    side?: BitMexSide;
     price?: number;
     orderQty?: number;
     ordStatus?: string;
@@ -235,7 +237,7 @@ export type BitMexWallet = {
 
 export type BitMexPlaceOrderRequest = {
     symbol: string;
-    side: 'Buy' | 'Sell';
+    side: BitMexSide;
     orderQty: number;
     price?: number;
     clOrdID?: string;


### PR DESCRIPTION
## Summary
- add placeOrder, changeOrder, and deleteOrder to BitMex transport
- implement REST-based order management with HMAC signing

## Testing
- `npm test -- --passWithNoTests`
- `npm run lint` *(fails: 'core' is defined but never used, etc.)*
- `npm run type-check` *(fails: Property '#instruments' has no initializer, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c6a49b754483208b8464a258dadce9