### PR TITLE
feat(bitmex): refine types and enums

### DIFF
--- a/src/cores/bitmex/types.ts
+++ b/src/cores/bitmex/types.ts
@@ -478,51 +478,41 @@ export type BitMexWallet = {
     withdrawn?: number;
 };
 
-export type BitMexPlaceOrderRequest = Omit<
-    BitMexOrder,
-    | 'orderID'
-    | 'account'
-    | 'cumQty'
-    | 'leavesQty'
-    | 'simpleLeavesQty'
-    | 'simpleCumQty'
-    | 'avgPx'
-    | 'ordStatus'
-    | 'triggered'
-    | 'workingIndicator'
-    | 'ordRejReason'
-    | 'timestamp'
-    | 'transactTime'
-    | 'multiLegReportingType'
-    | 'currency'
-    | 'settlCurrency'
->;
+export type BitMexPlaceOrderRequest = {
+    symbol: string;
+    side?: BitMexSide;
+    simpleOrderQty?: number;
+    orderQty?: number;
+    price?: number;
+    displayQty?: number;
+    stopPx?: number;
+    clOrdID?: string;
+    clOrdLinkID?: string;
+    pegOffsetValue?: number;
+    pegPriceType?: BitMexPegPriceType;
+    ordType?: BitMexOrderType;
+    timeInForce?: BitMexTimeInForce;
+    execInst?: BitMexExecInst;
+    contingencyType?: BitMexContingencyType;
+    text?: string;
+};
 
-export type BitMexChangeOrderRequest = Omit<
-    BitMexOrder,
-    | 'symbol'
-    | 'side'
-    | 'ordType'
-    | 'timeInForce'
-    | 'execInst'
-    | 'contingencyType'
-    | 'ordStatus'
-    | 'account'
-    | 'currency'
-    | 'settlCurrency'
-    | 'timestamp'
-    | 'transactTime'
-    | 'triggered'
-    | 'workingIndicator'
-    | 'ordRejReason'
-    | 'cumQty'
-    | 'simpleCumQty'
-    | 'avgPx'
-    | 'multiLegReportingType'
-    | 'orderID'
-> & {
+export type BitMexChangeOrderRequest = {
     orderID?: string;
     origClOrdID?: string;
+    clOrdID?: string;
+    simpleOrderQty?: number;
+    orderQty?: number;
+    simpleLeavesQty?: number;
+    leavesQty?: number;
+    price?: number;
+    stopPx?: number;
+    pegOffsetValue?: number;
+    pegPriceType?: BitMexPegPriceType;
+    ordType?: BitMexOrderType;
+    timeInForce?: BitMexTimeInForce;
+    execInst?: BitMexExecInst;
+    text?: string;
 };
 
 export type BitMexRequestVerb = 'GET' | 'POST' | 'PUT' | 'DELETE';

--- a/src/cores/bitmex/types.ts
+++ b/src/cores/bitmex/types.ts
@@ -34,6 +34,56 @@ export type BitMexOrderType =
     | 'StopMarket'
     | 'Pegged';
 
+export type BitMexOrderStatus =
+    | 'New'
+    | 'PartiallyFilled'
+    | 'Filled'
+    | 'Canceled'
+    | 'Rejected'
+    | 'Triggered'
+    | 'Expired';
+
+export type BitMexTimeInForce = 'Day' | 'GoodTillCancel' | 'ImmediateOrCancel' | 'FillOrKill' | 'GoodTillDate';
+
+export type BitMexExecInst =
+    | 'ParticipateDoNotInitiate'
+    | 'AllOrNone'
+    | 'MarkPrice'
+    | 'LastPrice'
+    | 'IndexPrice'
+    | 'Close'
+    | 'ReduceOnly'
+    | 'Fixed'
+    | 'Trail';
+
+export type BitMexContingencyType =
+    | 'OneCancelsTheOther'
+    | 'OneTriggersTheOther'
+    | 'OneUpdatesTheOtherAbsolute'
+    | 'OneUpdatesTheOtherProportional';
+
+export type BitMexPegPriceType = 'LastPeg' | 'MidPricePeg' | 'MarketPeg' | 'PrimaryPeg' | 'TrailingStopPeg';
+
+export type BitMexSettlementType = 'Settlement' | 'Delivery' | 'Termination' | 'Maturity';
+
+export type BitMexTickDirection = 'PlusTick' | 'ZeroPlusTick' | 'MinusTick' | 'ZeroMinusTick';
+
+export type BitMexExecType =
+    | 'New'
+    | 'Trade'
+    | 'Funding'
+    | 'Settlement'
+    | 'Canceled'
+    | 'Calculated'
+    | 'Expired'
+    | 'Restated';
+
+export type BitMexLastLiquidityInd = 'AddedLiquidity' | 'RemovedLiquidity' | 'LiquidityIndeterminate';
+
+export type BitMexTransactType = 'Withdrawal' | 'Deposit' | 'Transfer' | 'Settlement' | 'Rebate' | 'Reward' | 'Fee';
+
+export type BitMexTransactStatus = 'Pending' | 'Completed' | 'Canceled' | 'Rejected';
+
 export type BitMexChannelMessageAction = 'partial' | 'insert' | 'update' | 'delete';
 
 export type BitMexChannelMessage<Channel extends BitMexChannel> = {
@@ -165,6 +215,11 @@ export type BitMexTrade = {
     side: BitMexSide;
     size: number;
     price: number;
+    tickDirection?: BitMexTickDirection;
+    trdType?: string;
+    grossValue?: number;
+    homeNotional?: number;
+    foreignNotional?: number;
     timestamp: string;
 };
 
@@ -182,72 +237,76 @@ export type BitMexOrderBookL2 = {
     side: BitMexSide;
     size?: number;
     price?: number;
+    timestamp?: string;
+    transactTime?: string;
 };
 
 export type BitMexSettlement = {
     timestamp: string;
     symbol: string;
-    settlementType: string;
-    settlePrice?: number;
+    settlementType: BitMexSettlementType;
+    settledPrice?: number;
+    optionStrikePrice?: number;
+    optionUnderlyingPrice?: number;
+    bankrupt?: number;
+    taxBase?: number;
+    taxRate?: number;
 };
 
 export type BitMexExecution = {
     execID: string;
     orderID: string;
     clOrdID?: string;
+    clOrdLinkID?: string;
+    account?: number;
     symbol: string;
     side?: BitMexSide;
     price?: number;
-    size?: number;
+    orderQty?: number;
+    displayQty?: number;
+    stopPx?: number;
+    pegOffsetValue?: number;
+    pegPriceType?: BitMexPegPriceType;
+    currency?: string;
+    settlCurrency?: string;
+    execType?: BitMexExecType;
+    ordType?: BitMexOrderType;
+    ordStatus?: BitMexOrderStatus;
+    execInst?: BitMexExecInst;
+    contingencyType?: BitMexContingencyType;
+    timeInForce?: BitMexTimeInForce;
+    leavesQty?: number;
+    cumQty?: number;
+    avgPx?: number;
+    commission?: number;
+    lastPx?: number;
+    lastQty?: number;
+    lastLiquidityInd?: BitMexLastLiquidityInd;
+    text?: string;
+    trdMatchID?: string;
+    trdType?: string;
+    tradePublishIndicator?: string;
+    transactTime?: string;
+    timestamp?: string;
+    grossValue?: number;
+    homeNotional?: number;
+    foreignNotional?: number;
+    execCost?: number;
+    execComm?: number;
+    brokerCommission?: number;
+    brokerExecComm?: number;
+    feeType?: string;
+    realisedPnl?: number;
+    triggered?: string;
+    ordRejReason?: string;
+    workingIndicator?: boolean;
 };
 
 export type BitMexOrder = {
     orderID: string;
     clOrdID?: string;
-    symbol: string;
-    side?: BitMexSide;
-    price?: number;
-    orderQty?: number;
-    ordStatus?: string;
-};
-
-export type BitMexMargin = {
-    account: number;
-    currency: string;
-    riskLimit: number;
-    marginBalance: number;
-    availableMargin: number;
-};
-
-export type BitMexPosition = {
-    account: number;
-    symbol: string;
-    currentQty?: number;
-    avgEntryPrice?: number;
-    liquidationPrice?: number;
-};
-
-export type BitMexTransact = {
-    transactID: string;
-    account: number;
-    currency: string;
-    transactType?: string;
-    amount: number;
-    fee?: number;
-    transactStatus?: string;
-    address?: string;
-    timestamp?: string;
-};
-
-export type BitMexWallet = {
-    account: number;
-    currency: string;
-    balance: number;
-    availableMargin?: number;
-    walletBalance?: number;
-};
-
-export type BitMexPlaceOrderRequest = {
+    clOrdLinkID?: string;
+    account?: number;
     symbol: string;
     side?: BitMexSide;
     simpleOrderQty?: number;
@@ -255,29 +314,203 @@ export type BitMexPlaceOrderRequest = {
     price?: number;
     displayQty?: number;
     stopPx?: number;
-    clOrdID?: string;
-    clOrdLinkID?: string;
     pegOffsetValue?: number;
-    pegPriceType?: string;
+    pegPriceType?: BitMexPegPriceType;
+    currency?: string;
+    settlCurrency?: string;
     ordType?: BitMexOrderType;
-    timeInForce?: string;
-    execInst?: string;
-    contingencyType?: string;
+    timeInForce?: BitMexTimeInForce;
+    execInst?: BitMexExecInst;
+    contingencyType?: BitMexContingencyType;
+    ordStatus?: BitMexOrderStatus;
+    triggered?: string;
+    workingIndicator?: boolean;
+    ordRejReason?: string;
+    leavesQty?: number;
+    cumQty?: number;
+    avgPx?: number;
+    multiLegReportingType?: string;
     text?: string;
+    transactTime?: string;
+    timestamp?: string;
+    simpleLeavesQty?: number;
+    simpleCumQty?: number;
 };
 
-export type BitMexChangeOrderRequest = {
+export type BitMexMargin = {
+    account: number;
+    currency: string;
+    riskLimit: number;
+    riskValue?: number;
+    amount?: number;
+    marginBalance: number;
+    availableMargin: number;
+    grossComm?: number;
+    grossOpenCost?: number;
+    grossOpenPremium?: number;
+    grossExecCost?: number;
+    grossMarkValue?: number;
+    realisedPnl?: number;
+    unrealisedPnl?: number;
+    prevRealisedPnl?: number;
+    initMargin?: number;
+    maintMargin?: number;
+    targetExcessMargin?: number;
+    excessMargin?: number;
+    makerFeeDiscount?: number;
+    takerFeeDiscount?: number;
+    marginLeverage?: number;
+    marginUsedPcnt?: number;
+    withdrawableMargin?: number;
+    timestamp?: string;
+    foreignMarginBalance?: number;
+    foreignRequirement?: number;
+    state?: string;
+    walletBalance?: number;
+};
+
+export type BitMexPosition = {
+    account: number;
+    symbol: string;
+    currency?: string;
+    underlying?: string;
+    quoteCurrency?: string;
+    commission?: number;
+    initMarginReq?: number;
+    maintMarginReq?: number;
+    riskLimit?: number;
+    riskValue?: number;
+    leverage?: number;
+    crossMargin?: boolean;
+    deleveragePercentile?: number;
+    rebalancedPnl?: number;
+    prevRealisedPnl?: number;
+    prevUnrealisedPnl?: number;
+    openingQty?: number;
+    openOrderBuyQty?: number;
+    openOrderBuyCost?: number;
+    openOrderBuyPremium?: number;
+    openOrderSellQty?: number;
+    openOrderSellCost?: number;
+    openOrderSellPremium?: number;
+    currentQty?: number;
+    currentCost?: number;
+    currentComm?: number;
+    realisedCost?: number;
+    unrealisedCost?: number;
+    grossOpenCost?: number;
+    grossOpenPremium?: number;
+    posCost?: number;
+    posCost2?: number;
+    posCross?: number;
+    posLoss?: number;
+    posMaint?: number;
+    posMargin?: number;
+    posComm?: number;
+    posState?: string;
+    homeNotional?: number;
+    foreignNotional?: number;
+    liquidationPrice?: number;
+    bankruptPrice?: number;
+    marginCallPrice?: number;
+    avgEntryPrice?: number;
+    avgCostPrice?: number;
+    breakEvenPrice?: number;
+    markPrice?: number;
+    markValue?: number;
+    timestamp?: string;
+    realisedPnl?: number;
+    unrealisedPnl?: number;
+    unrealisedPnlPcnt?: number;
+    unrealisedRoePcnt?: number;
+    simpleQty?: number;
+    simpleCost?: number;
+    simpleValue?: number;
+    simplePnl?: number;
+    simplePnlPcnt?: number;
+    isOpen?: boolean;
+    maintMargin?: number;
+    initMargin?: number;
+};
+
+export type BitMexTransact = {
+    transactID: string;
+    account: number;
+    currency: string;
+    transactType?: BitMexTransactType;
+    amount: number;
+    fee?: number;
+    transactStatus?: BitMexTransactStatus;
+    address?: string;
+    tx?: string;
+    orderID?: string;
+    walletBalance?: number;
+    timestamp?: string;
+    transactTime?: string;
+    text?: string;
+    network?: string;
+    memo?: string;
+};
+
+export type BitMexWallet = {
+    account: number;
+    currency: string;
+    amount: number;
+    pendingCredit?: number;
+    pendingDebit?: number;
+    confirmedDebit?: number;
+    transferIn?: number;
+    transferOut?: number;
+    timestamp?: string;
+    deposited?: number;
+    withdrawn?: number;
+};
+
+export type BitMexPlaceOrderRequest = Omit<
+    BitMexOrder,
+    | 'orderID'
+    | 'account'
+    | 'cumQty'
+    | 'leavesQty'
+    | 'simpleLeavesQty'
+    | 'simpleCumQty'
+    | 'avgPx'
+    | 'ordStatus'
+    | 'triggered'
+    | 'workingIndicator'
+    | 'ordRejReason'
+    | 'timestamp'
+    | 'transactTime'
+    | 'multiLegReportingType'
+    | 'currency'
+    | 'settlCurrency'
+>;
+
+export type BitMexChangeOrderRequest = Omit<
+    BitMexOrder,
+    | 'symbol'
+    | 'side'
+    | 'ordType'
+    | 'timeInForce'
+    | 'execInst'
+    | 'contingencyType'
+    | 'ordStatus'
+    | 'account'
+    | 'currency'
+    | 'settlCurrency'
+    | 'timestamp'
+    | 'transactTime'
+    | 'triggered'
+    | 'workingIndicator'
+    | 'ordRejReason'
+    | 'cumQty'
+    | 'simpleCumQty'
+    | 'avgPx'
+    | 'multiLegReportingType'
+    | 'orderID'
+> & {
     orderID?: string;
     origClOrdID?: string;
-    clOrdID?: string;
-    simpleOrderQty?: number;
-    orderQty?: number;
-    simpleLeavesQty?: number;
-    leavesQty?: number;
-    price?: number;
-    stopPx?: number;
-    pegOffsetValue?: number;
-    text?: string;
 };
 
 export type BitMexRequestVerb = 'GET' | 'POST' | 'PUT' | 'DELETE';

--- a/src/cores/bitmex/types.ts
+++ b/src/cores/bitmex/types.ts
@@ -68,6 +68,18 @@ export type BitMexSettlementType = 'Settlement' | 'Delivery' | 'Termination' | '
 
 export type BitMexTickDirection = 'PlusTick' | 'ZeroPlusTick' | 'MinusTick' | 'ZeroMinusTick';
 
+export type BitMexTradeType = 'Regular' | 'BlockTrade';
+
+export type BitMexInstrumentType =
+    | 'FFWCSX'
+    | 'FFCCSX'
+    | 'FFICSX'
+    | 'IFXXXP'
+    | 'MRBXXX'
+    | 'MRCXXX'
+    | 'MRIXXX'
+    | 'MRRXXX';
+
 export type BitMexExecType =
     | 'New'
     | 'Trade'
@@ -110,7 +122,7 @@ export type BitMexInstrument = {
     symbol: string;
     rootSymbol?: string;
     state?: string;
-    typ?: string;
+    typ?: BitMexInstrumentType;
     listing?: string;
     front?: string;
     expiry?: string;
@@ -182,7 +194,7 @@ export type BitMexInstrument = {
     lowPrice?: number;
     lastPrice?: number;
     lastPriceProtected?: number;
-    lastTickDirection?: string;
+    lastTickDirection?: BitMexTickDirection;
     lastChangePcnt?: number;
     bidPrice?: number;
     midPrice?: number;
@@ -216,7 +228,7 @@ export type BitMexTrade = {
     size: number;
     price: number;
     tickDirection?: BitMexTickDirection;
-    trdType?: string;
+    trdType?: BitMexTradeType;
     grossValue?: number;
     homeNotional?: number;
     foreignNotional?: number;
@@ -284,7 +296,7 @@ export type BitMexExecution = {
     lastLiquidityInd?: BitMexLastLiquidityInd;
     text?: string;
     trdMatchID?: string;
-    trdType?: string;
+    trdType?: BitMexTradeType;
     tradePublishIndicator?: string;
     transactTime?: string;
     timestamp?: string;


### PR DESCRIPTION
## Summary
- expand BitMEX entity interfaces with missing fields
- introduce dedicated enums for constrained values
- derive order request types from base order via `Omit`

## Testing
- `npm run format`
- `npm run lint` (fails: 'data' is defined but never used...)
- `npm test` (fails: No tests found)
- `npm run type-check` (fails: Property '#instruments' has no initializer...)


------
https://chatgpt.com/codex/tasks/task_e_68c6ed3e8e008320bb44d8420327e421