### PR TITLE
feat: add built-in logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,46 @@
+# ExchangeHub
+
+## Logging
+
+ExchangeHub ships with a lightweight logger that works out-of-the-box in Node.js 22.
+It exposes the usual console-like API while adding log levels and structured context.
+The logger writes formatted messages to stdout/stderr using ISO timestamps, for example:
+
+```
+[2024-05-05T08:00:00.000Z] INFO exchange-hub: ExchangeHub initialized
+```
+
+### Configure the level
+
+The log level can be configured globally. By default it is set to `info`.
+
+- Environment variable (takes effect on startup):
+  ```bash
+  EXH_LOG_LEVEL=debug node app.js
+  ```
+- Programmatically at runtime:
+  ```ts
+  import { createLogger } from 'exchange-hub';
+
+  const log = createLogger('my-bot');
+  log.setLevel('trace');
+  ```
+
+Supported levels in ascending order are `trace`, `debug`, `info`, `warn`, and `error`.
+Calls below the active level are no-ops and do not perform formatting work.
+
+### Usage examples
+
+```ts
+import { createLogger } from 'exchange-hub';
+
+const log = createLogger('orders');
+const orderId = '123';
+
+log.info('Placed order %s', orderId, { symbol: 'btcusdt' });
+log.warn('Retrying request %d/3', 2);
+log.error('Request failed', new Error('timeout'));
+```
+
+Passing a trailing object attaches context to the message. It will be stringified lazily
+only when the log level allows the message to be emitted.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,7 @@
-console.log('ExchangeHub initialized');
+import { createLogger } from './infra/logger';
+
+const log = createLogger('exchange-hub');
+log.info('ExchangeHub initialized');
+
+export { createLogger, getLevel, setLevel } from './infra/logger';
+export type { LogLevel, Logger } from './infra/logger';

--- a/src/infra/logger.ts
+++ b/src/infra/logger.ts
@@ -1,0 +1,141 @@
+import { format, inspect } from 'node:util';
+
+export type LogLevel = 'trace' | 'debug' | 'info' | 'warn' | 'error';
+
+const LEVELS: readonly LogLevel[] = ['trace', 'debug', 'info', 'warn', 'error'];
+const LEVEL_PRIORITY: Record<LogLevel, number> = {
+  trace: 0,
+  debug: 1,
+  info: 2,
+  warn: 3,
+  error: 4,
+};
+
+const PLACEHOLDER_REGEX = /%[sdifjoOc]/g;
+
+type LogContext = Record<string, unknown>;
+
+function normalizeLevel(level?: string | LogLevel | null): LogLevel | undefined {
+  if (!level) {
+    return undefined;
+  }
+  const normalized = String(level).toLowerCase() as LogLevel;
+  return LEVELS.includes(normalized) ? normalized : undefined;
+}
+
+let globalLevel: LogLevel = normalizeLevel(process.env.EXH_LOG_LEVEL) ?? 'info';
+
+export function setLevel(level: LogLevel | string): void {
+  const normalized = normalizeLevel(level);
+  if (normalized) {
+    globalLevel = normalized;
+  }
+}
+
+export function getLevel(): LogLevel {
+  return globalLevel;
+}
+
+function shouldLog(level: LogLevel): boolean {
+  return LEVEL_PRIORITY[level] >= LEVEL_PRIORITY[globalLevel];
+}
+
+function isPlainObject(value: unknown): value is LogContext {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  if (Array.isArray(value)) {
+    return false;
+  }
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function stringifyContext(context: LogContext): string {
+  try {
+    return JSON.stringify(context);
+  } catch (error) {
+    return inspect(context, { depth: null, compact: true, breakLength: Infinity });
+  }
+}
+
+function formatMessage(args: unknown[]): string {
+  if (args.length === 0) {
+    return '';
+  }
+
+  let context: LogContext | undefined;
+  let formatArgs = args;
+
+  const candidate = args.at(-1);
+  if (candidate && isPlainObject(candidate)) {
+    const template = args[0];
+    const placeholders = typeof template === 'string' ? countPlaceholders(template) : 0;
+    const substitutionArgs = typeof template === 'string' ? args.length - 2 : 0;
+
+    if (typeof template === 'string' && placeholders <= substitutionArgs) {
+      context = candidate;
+      formatArgs = args.slice(0, -1);
+    }
+  }
+
+  const baseMessage = formatArgs.length > 0 ? format(...(formatArgs as [unknown, ...unknown[]])) : '';
+
+  if (!context) {
+    return baseMessage;
+  }
+
+  const messageWithContext = `${baseMessage}${baseMessage ? ' ' : ''}${stringifyContext(context)}`;
+  return messageWithContext.trim();
+}
+
+function countPlaceholders(template: string): number {
+  let count = 0;
+  PLACEHOLDER_REGEX.lastIndex = 0;
+  while (PLACEHOLDER_REGEX.exec(template) !== null) {
+    count += 1;
+  }
+  return count;
+}
+
+function formatLine(level: LogLevel, namespace: string | undefined, args: unknown[]): string {
+  const message = formatMessage(args);
+  const time = new Date().toISOString();
+  const levelLabel = level.toUpperCase();
+  const scope = namespace ? ` ${namespace}` : '';
+  const separator = message ? ': ' : '';
+  return `[${time}] ${levelLabel}${scope}${separator}${message}`;
+}
+
+function createWriter(level: LogLevel, namespace?: string) {
+  const stream = level === 'error' || level === 'warn' ? process.stderr : process.stdout;
+  return (...args: unknown[]) => {
+    if (!shouldLog(level)) {
+      return;
+    }
+    const line = formatLine(level, namespace, args);
+    stream.write(`${line}\n`);
+  };
+}
+
+export interface Logger {
+  level(): LogLevel;
+  setLevel(level: LogLevel | string): void;
+  trace: (...args: unknown[]) => void;
+  debug: (...args: unknown[]) => void;
+  info: (...args: unknown[]) => void;
+  warn: (...args: unknown[]) => void;
+  error: (...args: unknown[]) => void;
+}
+
+export function createLogger(namespace?: string): Logger {
+  return {
+    level: () => getLevel(),
+    setLevel,
+    trace: createWriter('trace', namespace),
+    debug: createWriter('debug', namespace),
+    info: createWriter('info', namespace),
+    warn: createWriter('warn', namespace),
+    error: createWriter('error', namespace),
+  };
+}


### PR DESCRIPTION
## Summary
- add a lightweight logger with level control and structured context support
- replace direct console logging in the package entrypoint and expose the logger API
- document configuration and usage examples for the new logger in the README

## Testing
- npm run build
- npm run lint *(fails: ESLint couldn't find the config "prettier" to extend from)*

------
https://chatgpt.com/codex/tasks/task_e_68ca6ae4288c832093a283bd8e61e79a