### PR TITLE
test: add jest smoke tests for infra modules

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -27,5 +27,5 @@ jobs:
         run: npm run format:check
       - name: Build
         run: npm run build
-      - name: Test (stub)
+      - name: Test
         run: npm test

--- a/README.md
+++ b/README.md
@@ -51,12 +51,7 @@ only when the log level allows the message to be emitted.
 Библиотека использует унифицированную иерархию ошибок с кодами и сериализацией:
 
 ```ts
-import {
-  fromHttpResponse,
-  NetworkError,
-  RateLimitError,
-  wrap,
-} from 'exchange-hub';
+import { fromHttpResponse, NetworkError, RateLimitError, wrap } from 'exchange-hub';
 
 async function fetchOrders() {
   try {

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,12 @@
-module.exports = {
-  preset: 'ts-jest/presets/js-with-ts',
+export default {
+  preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
-  // Ignore the compiled output to avoid duplicate mocks and tests
-  testPathIgnorePatterns: ['<rootDir>/dist/'],
-  modulePathIgnorePatterns: ['<rootDir>/dist/'],
+  transform: {
+    '^.+\\.ts$': ['ts-jest', { tsconfig: 'tsconfig.json', useESM: true, diagnostics: false }],
+  },
+  extensionsToTreatAsEsm: ['.ts'],
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+  },
+  collectCoverageFrom: ['src/**/*.ts', '!src/**/*.d.ts'],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.10.0",
-        "@types/jest": "^29",
+        "@types/jest": "^29.5.12",
         "@types/node": "^20.14.0",
         "@typescript-eslint/eslint-plugin": "^8.5.0",
         "@typescript-eslint/parser": "^8.5.0",
@@ -24,10 +24,10 @@
         "eslint-plugin-prettier": "^5.1.3",
         "eslint-plugin-unused-imports": "^4.1.4",
         "globals": "^16.3.0",
-        "jest": "^29",
+        "jest": "^29.7.0",
         "nock": "^14.0.6",
         "prettier": "^3.3.3",
-        "ts-jest": "^29.4.0",
+        "ts-jest": "^29.2.5",
         "ts-node": "^10.9.2",
         "typescript": "^5.5.0"
       },

--- a/package.json
+++ b/package.json
@@ -14,7 +14,10 @@
     "lint:fix": "ESLINT_USE_FLAT_CONFIG=false eslint . --ext .ts,.tsx,.mts,.cts --fix",
     "format": "prettier . --write",
     "format:check": "prettier . --check",
-    "test": "node -e \"console.log('no tests yet')\"",
+    "pretest": "npm run type-check",
+    "test": "jest --passWithNoTests",
+    "test:watch": "jest --watch",
+    "test:ci": "jest --coverage --coverageReporters=text",
     "exp": "node ./scripts/run-example.js"
   },
   "repository": {
@@ -29,7 +32,7 @@
   "homepage": "https://github.com/felis2803/exchange-hub#readme",
   "devDependencies": {
     "@eslint/js": "^9.10.0",
-    "@types/jest": "^29",
+    "@types/jest": "^29.5.12",
     "@types/node": "^20.14.0",
     "@typescript-eslint/eslint-plugin": "^8.5.0",
     "@typescript-eslint/parser": "^8.5.0",
@@ -40,10 +43,10 @@
     "eslint-plugin-prettier": "^5.1.3",
     "eslint-plugin-unused-imports": "^4.1.4",
     "globals": "^16.3.0",
-    "jest": "^29",
+    "jest": "^29.7.0",
     "nock": "^14.0.6",
     "prettier": "^3.3.3",
-    "ts-jest": "^29.4.0",
+    "ts-jest": "^29.2.5",
     "ts-node": "^10.9.2",
     "typescript": "^5.5.0"
   },

--- a/tests/errors.test.ts
+++ b/tests/errors.test.ts
@@ -1,0 +1,39 @@
+import {
+  BaseError,
+  NetworkError,
+  RateLimitError,
+  ExchangeDownError,
+  fromWsClose,
+  fromHttpResponse,
+  wrap,
+} from '../src/infra/errors.js';
+
+describe('errors (smoke)', () => {
+  test('hierarchy and toJSON', () => {
+    const err = new NetworkError('net fail', { details: { a: 1 } });
+    expect(err).toBeInstanceOf(BaseError);
+    const json = err.toJSON();
+    expect(json.code).toBe('NETWORK_ERROR');
+    expect(json.message).toContain('net fail');
+    expect(json.details).toEqual({ a: 1 });
+  });
+
+  test('fromWsClose mapping', () => {
+    expect(fromWsClose({ code: 1000 }).code).toBe('NETWORK_ERROR');
+    expect(fromWsClose({ code: 1006 }).code).toBe('EXCHANGE_DOWN');
+    expect(fromWsClose({ code: 1011 }).code).toBe('EXCHANGE_DOWN');
+  });
+
+  test('fromHttpResponse basic mapping', () => {
+    const e429 = fromHttpResponse({ status: 429, url: '/x', method: 'GET', retryAfterMs: 2000 });
+    expect(e429).toBeInstanceOf(RateLimitError);
+    const e503 = fromHttpResponse({ status: 503, url: '/x', method: 'GET' });
+    expect(e503).toBeInstanceOf(ExchangeDownError);
+  });
+
+  test('wrap unknown', () => {
+    const e = wrap('boom');
+    expect(e).toBeInstanceOf(BaseError);
+    expect(e.code).toBe('UNKNOWN_ERROR');
+  });
+});

--- a/tests/logger.test.ts
+++ b/tests/logger.test.ts
@@ -1,0 +1,12 @@
+import { createLogger } from '../src/infra/logger.js';
+
+describe('logger (smoke)', () => {
+  test('create logger and log at all levels without throwing', () => {
+    const log = createLogger('jest-smoke');
+    expect(() => log.trace('trace %s', 'ok', { ctx: 1 })).not.toThrow();
+    expect(() => log.debug('debug %d', 2)).not.toThrow();
+    expect(() => log.info('info')).not.toThrow();
+    expect(() => log.warn('warn', { warn: true })).not.toThrow();
+    expect(() => log.error('error')).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- configure Jest with ts-jest for the ESM TypeScript build and expose npm scripts for local/CI runs
- add smoke tests for the logger and error helpers to verify basic flows
- update the CI workflow to run the real Jest suite instead of the placeholder

## Testing
- npm test
- npm run test:ci
- npm run lint
- npm run format:check
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ca86dea72883208a7eb6dae008da5b