### PR TITLE
Fix lint warnings in BitMex handlers and examples

### DIFF
--- a/examples/bitmex-bot/index.ts
+++ b/examples/bitmex-bot/index.ts
@@ -1,3 +1,5 @@
+/* eslint-disable no-console */
+
 import { ExchangeHub } from '../../src/ExchangeHub';
 
 async function main() {

--- a/examples/subs/index.ts
+++ b/examples/subs/index.ts
@@ -1,3 +1,5 @@
+/* eslint-disable no-console */
+
 const ws = new WebSocket('wss://ws.bitmex.com/realtime?subscribe=instrument');
 
 ws.onopen = () => {

--- a/src/cores/bitmex/channelMessageHandlers/execution.ts
+++ b/src/cores/bitmex/channelMessageHandlers/execution.ts
@@ -2,19 +2,19 @@ import type { BitMex } from '../index.js';
 import type { BitMexExecution } from '../types.js';
 
 export const execution = {
-  partial(core: BitMex, data: BitMexExecution[]) {
+  partial(_core: BitMex, _data: BitMexExecution[]) {
     throw 'not implemented';
   },
 
-  insert(core: BitMex, data: BitMexExecution[]) {
+  insert(_core: BitMex, _data: BitMexExecution[]) {
     throw 'not implemented';
   },
 
-  update(core: BitMex, data: BitMexExecution[]) {
+  update(_core: BitMex, _data: BitMexExecution[]) {
     throw 'not implemented';
   },
 
-  delete(core: BitMex, data: BitMexExecution[]) {
+  delete(_core: BitMex, _data: BitMexExecution[]) {
     throw 'not implemented';
   },
 };

--- a/src/cores/bitmex/channelMessageHandlers/liquidation.ts
+++ b/src/cores/bitmex/channelMessageHandlers/liquidation.ts
@@ -2,19 +2,19 @@ import type { BitMex } from '../index.js';
 import type { BitMexLiquidation } from '../types.js';
 
 export const liquidation = {
-  partial(core: BitMex, data: BitMexLiquidation[]) {
+  partial(_core: BitMex, _data: BitMexLiquidation[]) {
     throw 'not implemented';
   },
 
-  insert(core: BitMex, data: BitMexLiquidation[]) {
+  insert(_core: BitMex, _data: BitMexLiquidation[]) {
     throw 'not implemented';
   },
 
-  update(core: BitMex, data: BitMexLiquidation[]) {
+  update(_core: BitMex, _data: BitMexLiquidation[]) {
     throw 'not implemented';
   },
 
-  delete(core: BitMex, data: BitMexLiquidation[]) {
+  delete(_core: BitMex, _data: BitMexLiquidation[]) {
     throw 'not implemented';
   },
 };

--- a/src/cores/bitmex/channelMessageHandlers/margin.ts
+++ b/src/cores/bitmex/channelMessageHandlers/margin.ts
@@ -2,19 +2,19 @@ import type { BitMex } from '../index.js';
 import type { BitMexMargin } from '../types.js';
 
 export const margin = {
-  partial(core: BitMex, data: BitMexMargin[]) {
+  partial(_core: BitMex, _data: BitMexMargin[]) {
     throw 'not implemented';
   },
 
-  insert(core: BitMex, data: BitMexMargin[]) {
+  insert(_core: BitMex, _data: BitMexMargin[]) {
     throw 'not implemented';
   },
 
-  update(core: BitMex, data: BitMexMargin[]) {
+  update(_core: BitMex, _data: BitMexMargin[]) {
     throw 'not implemented';
   },
 
-  delete(core: BitMex, data: BitMexMargin[]) {
+  delete(_core: BitMex, _data: BitMexMargin[]) {
     throw 'not implemented';
   },
 };

--- a/src/cores/bitmex/channelMessageHandlers/order.ts
+++ b/src/cores/bitmex/channelMessageHandlers/order.ts
@@ -2,19 +2,19 @@ import type { BitMex } from '../index.js';
 import type { BitMexOrder } from '../types.js';
 
 export const order = {
-  partial(core: BitMex, data: BitMexOrder[]) {
+  partial(_core: BitMex, _data: BitMexOrder[]) {
     throw 'not implemented';
   },
 
-  insert(core: BitMex, data: BitMexOrder[]) {
+  insert(_core: BitMex, _data: BitMexOrder[]) {
     throw 'not implemented';
   },
 
-  update(core: BitMex, data: BitMexOrder[]) {
+  update(_core: BitMex, _data: BitMexOrder[]) {
     throw 'not implemented';
   },
 
-  delete(core: BitMex, data: BitMexOrder[]) {
+  delete(_core: BitMex, _data: BitMexOrder[]) {
     throw 'not implemented';
   },
 };

--- a/src/cores/bitmex/channelMessageHandlers/orderBookL2.ts
+++ b/src/cores/bitmex/channelMessageHandlers/orderBookL2.ts
@@ -2,19 +2,19 @@ import type { BitMex } from '../index.js';
 import type { BitMexOrderBookL2 } from '../types.js';
 
 export const orderBookL2 = {
-  partial(core: BitMex, data: BitMexOrderBookL2[]) {
+  partial(_core: BitMex, _data: BitMexOrderBookL2[]) {
     throw 'not implemented';
   },
 
-  insert(core: BitMex, data: BitMexOrderBookL2[]) {
+  insert(_core: BitMex, _data: BitMexOrderBookL2[]) {
     throw 'not implemented';
   },
 
-  update(core: BitMex, data: BitMexOrderBookL2[]) {
+  update(_core: BitMex, _data: BitMexOrderBookL2[]) {
     throw 'not implemented';
   },
 
-  delete(core: BitMex, data: BitMexOrderBookL2[]) {
+  delete(_core: BitMex, _data: BitMexOrderBookL2[]) {
     throw 'not implemented';
   },
 };

--- a/src/cores/bitmex/channelMessageHandlers/position.ts
+++ b/src/cores/bitmex/channelMessageHandlers/position.ts
@@ -2,19 +2,19 @@ import type { BitMex } from '../index.js';
 import type { BitMexPosition } from '../types.js';
 
 export const position = {
-  partial(core: BitMex, data: BitMexPosition[]) {
+  partial(_core: BitMex, _data: BitMexPosition[]) {
     throw 'not implemented';
   },
 
-  insert(core: BitMex, data: BitMexPosition[]) {
+  insert(_core: BitMex, _data: BitMexPosition[]) {
     throw 'not implemented';
   },
 
-  update(core: BitMex, data: BitMexPosition[]) {
+  update(_core: BitMex, _data: BitMexPosition[]) {
     throw 'not implemented';
   },
 
-  delete(core: BitMex, data: BitMexPosition[]) {
+  delete(_core: BitMex, _data: BitMexPosition[]) {
     throw 'not implemented';
   },
 };

--- a/src/cores/bitmex/channelMessageHandlers/settlement.ts
+++ b/src/cores/bitmex/channelMessageHandlers/settlement.ts
@@ -2,19 +2,19 @@ import type { BitMex } from '../index.js';
 import type { BitMexSettlement } from '../types.js';
 
 export const settlement = {
-  partial(core: BitMex, data: BitMexSettlement[]) {
+  partial(_core: BitMex, _data: BitMexSettlement[]) {
     throw 'not implemented';
   },
 
-  insert(core: BitMex, data: BitMexSettlement[]) {
+  insert(_core: BitMex, _data: BitMexSettlement[]) {
     throw 'not implemented';
   },
 
-  update(core: BitMex, data: BitMexSettlement[]) {
+  update(_core: BitMex, _data: BitMexSettlement[]) {
     throw 'not implemented';
   },
 
-  delete(core: BitMex, data: BitMexSettlement[]) {
+  delete(_core: BitMex, _data: BitMexSettlement[]) {
     throw 'not implemented';
   },
 };

--- a/src/cores/bitmex/channelMessageHandlers/trade.ts
+++ b/src/cores/bitmex/channelMessageHandlers/trade.ts
@@ -2,19 +2,19 @@ import type { BitMex } from '../index.js';
 import type { BitMexTrade } from '../types.js';
 
 export const trade = {
-  partial(core: BitMex, data: BitMexTrade[]) {
+  partial(_core: BitMex, _data: BitMexTrade[]) {
     throw 'not implemented';
   },
 
-  insert(core: BitMex, data: BitMexTrade[]) {
+  insert(_core: BitMex, _data: BitMexTrade[]) {
     throw 'not implemented';
   },
 
-  update(core: BitMex, data: BitMexTrade[]) {
+  update(_core: BitMex, _data: BitMexTrade[]) {
     throw 'not implemented';
   },
 
-  delete(core: BitMex, data: BitMexTrade[]) {
+  delete(_core: BitMex, _data: BitMexTrade[]) {
     throw 'not implemented';
   },
 };

--- a/src/cores/bitmex/channelMessageHandlers/transact.ts
+++ b/src/cores/bitmex/channelMessageHandlers/transact.ts
@@ -2,19 +2,19 @@ import type { BitMex } from '../index.js';
 import type { BitMexTransact } from '../types.js';
 
 export const transact = {
-  partial(core: BitMex, data: BitMexTransact[]) {
+  partial(_core: BitMex, _data: BitMexTransact[]) {
     throw 'not implemented';
   },
 
-  insert(core: BitMex, data: BitMexTransact[]) {
+  insert(_core: BitMex, _data: BitMexTransact[]) {
     throw 'not implemented';
   },
 
-  update(core: BitMex, data: BitMexTransact[]) {
+  update(_core: BitMex, _data: BitMexTransact[]) {
     throw 'not implemented';
   },
 
-  delete(core: BitMex, data: BitMexTransact[]) {
+  delete(_core: BitMex, _data: BitMexTransact[]) {
     throw 'not implemented';
   },
 };

--- a/src/cores/bitmex/channelMessageHandlers/wallet.ts
+++ b/src/cores/bitmex/channelMessageHandlers/wallet.ts
@@ -2,19 +2,19 @@ import type { BitMex } from '../index.js';
 import type { BitMexWallet } from '../types.js';
 
 export const wallet = {
-  partial(core: BitMex, data: BitMexWallet[]) {
+  partial(_core: BitMex, _data: BitMexWallet[]) {
     throw 'not implemented';
   },
 
-  insert(core: BitMex, data: BitMexWallet[]) {
+  insert(_core: BitMex, _data: BitMexWallet[]) {
     throw 'not implemented';
   },
 
-  update(core: BitMex, data: BitMexWallet[]) {
+  update(_core: BitMex, _data: BitMexWallet[]) {
     throw 'not implemented';
   },
 
-  delete(core: BitMex, data: BitMexWallet[]) {
+  delete(_core: BitMex, _data: BitMexWallet[]) {
     throw 'not implemented';
   },
 };

--- a/src/cores/bitmex/index.ts
+++ b/src/cores/bitmex/index.ts
@@ -52,7 +52,7 @@ export class BitMex extends BaseCore<'BitMex'> {
       return this.#handleWelcomeMessage(message);
     }
 
-    console.log(message);
+    console.warn(message);
     throw new Error('Unknown message');
   }
 

--- a/src/infra/logger.ts
+++ b/src/infra/logger.ts
@@ -54,7 +54,7 @@ function isPlainObject(value: unknown): value is LogContext {
 function stringifyContext(context: LogContext): string {
   try {
     return JSON.stringify(context);
-  } catch (error) {
+  } catch {
     return inspect(context, { depth: null, compact: true, breakLength: Infinity });
   }
 }


### PR DESCRIPTION
## Summary
- prefix unused BitMex channel handler arguments with underscores to satisfy the unused vars rule
- allow console usage in the example scripts via a local ESLint directive
- switch the unknown message log to `console.warn` and drop an unused catch binding

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ca99a8a9c883208ba6219b36142d21