### PR TITLE
Add BitMEX REST client with HMAC signature

### DIFF
--- a/src/cores/bitmex/constants.ts
+++ b/src/cores/bitmex/constants.ts
@@ -26,3 +26,10 @@ export const BITMEX_REST_ENDPOINTS = {
   testnet: 'https://testnet.bitmex.com/api/v1',
   mainnet: 'https://www.bitmex.com/api/v1',
 } as const;
+
+export const BITMEX_REST_HOSTS = {
+  testnet: 'https://testnet.bitmex.com',
+  mainnet: 'https://www.bitmex.com',
+} as const;
+
+export const BITMEX_REST_DEFAULT_TIMEOUT_MS = 30_000;

--- a/src/cores/bitmex/rest/request.ts
+++ b/src/cores/bitmex/rest/request.ts
@@ -1,0 +1,127 @@
+import { AuthError, BaseError, fromFetchError, fromHttpResponse } from '../../../infra/errors.js';
+import { BITMEX_REST_DEFAULT_TIMEOUT_MS, BITMEX_REST_HOSTS } from '../constants.js';
+import { sign } from './sign.js';
+
+import type { BitMexInstrument } from '../types.js';
+
+export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'DELETE';
+
+export interface RequestInitEx {
+  qs?: Record<string, string | number | boolean | undefined>;
+  body?: unknown;
+  timeoutMs?: number;
+  auth?: boolean;
+}
+
+export interface BitmexRestClientOptions {
+  isTest?: boolean;
+  apiKey?: string;
+  apiSecret?: string;
+  defaultTimeoutMs?: number;
+}
+
+export class BitmexRestClient {
+  readonly baseUrl: string;
+  readonly apiKey?: string;
+  readonly apiSecret?: string;
+  readonly defaultTimeoutMs: number;
+
+  constructor(opts: BitmexRestClientOptions = {}) {
+    this.baseUrl = opts.isTest ? BITMEX_REST_HOSTS.testnet : BITMEX_REST_HOSTS.mainnet;
+    this.apiKey = opts.apiKey;
+    this.apiSecret = opts.apiSecret;
+    this.defaultTimeoutMs = opts.defaultTimeoutMs ?? BITMEX_REST_DEFAULT_TIMEOUT_MS;
+  }
+
+  async request<T>(method: HttpMethod, path: string, init: RequestInitEx = {}): Promise<T> {
+    const url = new URL(path, this.baseUrl);
+
+    if (init.qs) {
+      for (const [key, value] of Object.entries(init.qs)) {
+        if (value === undefined) continue;
+        url.searchParams.set(key, String(value));
+      }
+    }
+
+    const pathWithQuery = `${url.pathname}${url.search}`;
+
+    const hasBody = init.body !== undefined && init.body !== null;
+    let payloadBody = '';
+    let requestBody: string | undefined;
+
+    if (hasBody) {
+      payloadBody = typeof init.body === 'string' ? init.body : JSON.stringify(init.body);
+      requestBody = payloadBody;
+    }
+
+    const headers: Record<string, string> = { accept: 'application/json' };
+    if (hasBody) {
+      headers['content-type'] = 'application/json';
+    }
+
+    const hasCredentials = Boolean(this.apiKey && this.apiSecret);
+    const shouldSign = init.auth ?? (hasCredentials && path.startsWith('/api/'));
+
+    if (shouldSign) {
+      if (!hasCredentials) {
+        throw new AuthError('BitMEX API credentials required', { exchange: 'BitMEX' });
+      }
+
+      const expires = Math.floor(Date.now() / 1000) + 60;
+      const signature = sign(method, pathWithQuery, expires, payloadBody, this.apiSecret!);
+      headers['api-key'] = this.apiKey!;
+      headers['api-expires'] = String(expires);
+      headers['api-signature'] = signature;
+    }
+
+    const controller = new AbortController();
+    const timeoutMs = init.timeoutMs ?? this.defaultTimeoutMs;
+    const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+    try {
+      const response = await fetch(url.toString(), {
+        method,
+        headers,
+        body: requestBody,
+        signal: controller.signal,
+      });
+
+      const text = await response.text();
+      const parsed = text ? safeJsonParse(text) : undefined;
+      const payload = parsed ?? (text || undefined);
+
+      if (!response.ok) {
+        throw fromHttpResponse({
+          status: response.status,
+          body: payload,
+          headers: response.headers,
+          url: pathWithQuery,
+          method,
+          exchange: 'BitMEX',
+        });
+      }
+
+      return (parsed as T) ?? (undefined as unknown as T);
+    } catch (error) {
+      if (error instanceof BaseError) {
+        throw error;
+      }
+
+      throw fromFetchError(error, { exchange: 'BitMEX' });
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  getActiveInstruments(): Promise<BitMexInstrument[]> {
+    return this.request('GET', '/api/v1/instrument/active');
+  }
+}
+
+function safeJsonParse(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return undefined;
+  }
+}

--- a/src/cores/bitmex/rest/sign.ts
+++ b/src/cores/bitmex/rest/sign.ts
@@ -1,0 +1,21 @@
+import { createHmac } from 'node:crypto';
+
+/**
+ * BitMEX signature helper.
+ *
+ * The payload format is `${verb}${pathWithQuery}${expires}${body}` where:
+ * - `verb` must be upper-case HTTP method (GET/POST/...).
+ * - `pathWithQuery` is the request path, including leading slash and query string.
+ * - `expires` is the Unix timestamp in seconds used by BitMEX auth headers.
+ * - `body` is the raw JSON string (empty string for requests without body).
+ */
+export function sign(
+  verb: string,
+  pathWithQuery: string,
+  expires: number,
+  body: string,
+  apiSecret: string,
+): string {
+  const payload = `${verb.toUpperCase()}${pathWithQuery}${expires}${body}`;
+  return createHmac('sha256', apiSecret).update(payload).digest('hex');
+}

--- a/tests/rest/request.test.ts
+++ b/tests/rest/request.test.ts
@@ -1,0 +1,142 @@
+import { jest } from '@jest/globals';
+
+import { BitmexRestClient } from '../../src/cores/bitmex/rest/request.js';
+import { sign } from '../../src/cores/bitmex/rest/sign.js';
+import { AuthError, ExchangeDownError } from '../../src/infra/errors.js';
+
+describe('BitmexRestClient.request()', () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.restoreAllMocks();
+  });
+
+  test('GET builds url with query string and returns JSON payload', async () => {
+    const payload = [{ symbol: 'XBTUSD' }];
+    const mockFetch = jest.fn(async (input: RequestInfo | URL) => {
+      expect(String(input)).toBe('https://testnet.bitmex.com/api/v1/instrument/active?count=1');
+      return new Response(JSON.stringify(payload), { status: 200 });
+    });
+    global.fetch = mockFetch as unknown as typeof fetch;
+
+    const client = new BitmexRestClient({ isTest: true });
+    const data = await client.request('GET', '/api/v1/instrument/active', { qs: { count: 1 } });
+
+    expect(data).toEqual(payload);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const init = mockFetch.mock.calls[0][1] as RequestInit;
+    expect(init.headers).toEqual({ accept: 'application/json' });
+  });
+
+  test('getActiveInstruments() uses public endpoint', async () => {
+    const payload = [{ symbol: 'ETHUSD' }];
+    const mockFetch = jest.fn(async () => new Response(JSON.stringify(payload), { status: 200 }));
+    global.fetch = mockFetch as unknown as typeof fetch;
+
+    const client = new BitmexRestClient({ isTest: true });
+    const instruments = await client.getActiveInstruments();
+
+    expect(instruments).toEqual(payload);
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://testnet.bitmex.com/api/v1/instrument/active',
+      expect.any(Object),
+    );
+  });
+
+  test('adds auth headers when credentials provided and auth enabled', async () => {
+    const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(1_600_000_000_000);
+    const mockFetch = jest.fn(async () => new Response('[]', { status: 200 }));
+    global.fetch = mockFetch as unknown as typeof fetch;
+
+    const client = new BitmexRestClient({
+      apiKey: 'key',
+      apiSecret: 'secret',
+      isTest: false,
+    });
+
+    await client.request('POST', '/api/v1/order', {
+      auth: true,
+      body: { symbol: 'XBTUSD', orderQty: 1 },
+    });
+
+    const [, init] = mockFetch.mock.calls[0] as [RequestInfo | URL, RequestInit];
+    const headers = init.headers as Record<string, string>;
+    expect(headers['content-type']).toBe('application/json');
+    expect(headers['api-key']).toBe('key');
+    expect(headers['api-expires']).toBe(String(Math.floor(1_600_000_000_000 / 1000) + 60));
+    const expectedSignature = sign(
+      'POST',
+      '/api/v1/order',
+      Math.floor(1_600_000_000_000 / 1000) + 60,
+      JSON.stringify({ symbol: 'XBTUSD', orderQty: 1 }),
+      'secret',
+    );
+    expect(headers['api-signature']).toBe(expectedSignature);
+    nowSpy.mockRestore();
+  });
+
+  test('throws AuthError when auth requested without credentials', async () => {
+    const mockFetch = jest.fn();
+    global.fetch = mockFetch as unknown as typeof fetch;
+
+    const client = new BitmexRestClient({ isTest: true });
+    await expect(
+      client.request('GET', '/api/v1/user/margin', { auth: true }),
+    ).rejects.toBeInstanceOf(AuthError);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  test('maps 401 responses to AuthError', async () => {
+    const mockFetch = jest.fn(async () => new Response('Unauthorized', { status: 401 }));
+    global.fetch = mockFetch as unknown as typeof fetch;
+
+    const client = new BitmexRestClient({ apiKey: 'k', apiSecret: 's', isTest: true });
+    await expect(client.request('GET', '/api/v1/user/margin', { auth: true })).rejects.toBeInstanceOf(
+      AuthError,
+    );
+  });
+
+  test('maps 429 to RateLimitError with retryAfterMs', async () => {
+    const mockFetch = jest.fn(async () =>
+      new Response('{"error":"Too Many Requests"}', {
+        status: 429,
+        headers: { 'Retry-After': '2' },
+      }),
+    );
+    global.fetch = mockFetch as unknown as typeof fetch;
+
+    const client = new BitmexRestClient({ isTest: true });
+    await expect(client.request('GET', '/api/v1/instrument/active')).rejects.toMatchObject({
+      retryAfterMs: 2000,
+      code: 'RATE_LIMIT',
+    });
+  });
+
+  test('maps Retry-After date header to retryAfterMs', async () => {
+    const now = 1_700_000_000_000;
+    const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(now);
+    const retryDate = new Date(now + 5_000).toUTCString();
+    const mockFetch = jest.fn(async () =>
+      new Response('Too many', {
+        status: 429,
+        headers: { 'Retry-After': retryDate },
+      }),
+    );
+    global.fetch = mockFetch as unknown as typeof fetch;
+
+    const client = new BitmexRestClient({ isTest: true });
+    await expect(client.request('GET', '/api/v1/instrument/active')).rejects.toHaveProperty('retryAfterMs', 5000);
+    nowSpy.mockRestore();
+  });
+
+  test('maps 5xx to ExchangeDownError', async () => {
+    const mockFetch = jest.fn(async () => new Response('Server down', { status: 503 }));
+    global.fetch = mockFetch as unknown as typeof fetch;
+
+    const client = new BitmexRestClient({ isTest: true });
+    await expect(client.request('GET', '/api/v1/instrument/active')).rejects.toBeInstanceOf(
+      ExchangeDownError,
+    );
+  });
+});

--- a/tests/rest/sign.test.ts
+++ b/tests/rest/sign.test.ts
@@ -1,0 +1,8 @@
+import { sign } from '../../src/cores/bitmex/rest/sign.js';
+
+describe('BitMEX REST sign()', () => {
+  test('matches known signature from BitMEX docs', () => {
+    const hex = sign('GET', '/api/v1/instrument', 1518064236, '', 'secret');
+    expect(hex).toBe('0b4b0b0b49be3efa4c18d67e198a2b5b838d60bd1eb8f6b00214c74d0031728a');
+  });
+});


### PR DESCRIPTION
## Summary
- add BitMEX REST host constants and signing helper
- implement a minimal BitmexRestClient with HMAC auth support and the instrument/active call
- cover signing, request handling, and error mapping with new Jest tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68caaad067e08320867208e575a91584