### PR TITLE
feat(bitmex): resilient websocket transport

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,14 @@
       "version": "0.1.0",
       "license": "ISC",
       "dependencies": {
-        "rxjs": "^7.8.2"
+        "rxjs": "^7.8.2",
+        "ws": "^8.18.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.10.0",
         "@types/jest": "^29.5.12",
         "@types/node": "^20.14.0",
+        "@types/ws": "^8.5.12",
         "@typescript-eslint/eslint-plugin": "^8.5.0",
         "@typescript-eslint/parser": "^8.5.0",
         "eslint": "^9.10.0",
@@ -1588,6 +1590,16 @@
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/yargs": {
       "version": "17.0.33",
@@ -7395,6 +7407,27 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/y18n": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@eslint/js": "^9.10.0",
     "@types/jest": "^29.5.12",
     "@types/node": "^20.14.0",
+    "@types/ws": "^8.5.12",
     "@typescript-eslint/eslint-plugin": "^8.5.0",
     "@typescript-eslint/parser": "^8.5.0",
     "eslint": "^9.10.0",
@@ -51,6 +52,7 @@
     "typescript": "^5.5.0"
   },
   "dependencies": {
-    "rxjs": "^7.8.2"
+    "rxjs": "^7.8.2",
+    "ws": "^8.18.0"
   }
 }

--- a/src/cores/bitmex/constants.ts
+++ b/src/cores/bitmex/constants.ts
@@ -17,12 +17,19 @@ export const BITMEX_PRIVATE_CHANNELS = [
 
 export const BITMEX_CHANNELS = [...BITMEX_PUBLIC_CHANNELS, ...BITMEX_PRIVATE_CHANNELS] as const;
 
-export const BITMEX_WS_ENDPOINTS = {
-  testnet: 'wss://testnet.bitmex.com/realtime',
-  mainnet: 'wss://www.bitmex.com/realtime',
-} as const;
-
 export const BITMEX_REST_ENDPOINTS = {
   testnet: 'https://testnet.bitmex.com/api/v1',
   mainnet: 'https://www.bitmex.com/api/v1',
 } as const;
+
+export const BITMEX_WS_ENDPOINTS = {
+  mainnet: 'wss://www.bitmex.com/realtime',
+  testnet: 'wss://testnet.bitmex.com/realtime',
+} as const;
+
+export const WS_PING_INTERVAL_MS = 25_000; // 25s
+export const WS_PONG_TIMEOUT_MS = 15_000; // 15s
+export const WS_RECONNECT_MAX_ATTEMPTS = 12;
+export const WS_RECONNECT_BASE_DELAY_MS = 200; // min 200ms
+export const WS_RECONNECT_MAX_DELAY_MS = 10 * 60 * 1000; // 10min
+export const WS_SEND_BUFFER_LIMIT = 1_000;

--- a/src/cores/bitmex/transport/ws.ts
+++ b/src/cores/bitmex/transport/ws.ts
@@ -1,0 +1,476 @@
+import { EventEmitter } from 'node:events';
+
+import WebSocket, { RawData } from 'ws';
+
+import { createLogger } from '../../../infra/logger.js';
+import { ValidationError, fromWsClose } from '../../../infra/errors.js';
+import {
+  BITMEX_WS_ENDPOINTS,
+  WS_PING_INTERVAL_MS,
+  WS_PONG_TIMEOUT_MS,
+  WS_RECONNECT_BASE_DELAY_MS,
+  WS_RECONNECT_MAX_ATTEMPTS,
+  WS_RECONNECT_MAX_DELAY_MS,
+  WS_SEND_BUFFER_LIMIT,
+} from '../constants.js';
+
+export type WsState = 'idle' | 'connecting' | 'open' | 'closing' | 'reconnecting';
+
+export interface BitmexWsOptions {
+  isTest?: boolean;
+  url?: string;
+  pingIntervalMs?: number;
+  pongTimeoutMs?: number;
+  reconnect?: {
+    maxAttempts?: number;
+    baseDelayMs?: number;
+    maxDelayMs?: number;
+  };
+  sendBufferLimit?: number;
+}
+
+export interface BitmexWsEvents {
+  open: () => void;
+  close: (info: { code: number; reason?: string }) => void;
+  error: (err: Error) => void;
+  message: (raw: string) => void;
+}
+
+interface NormalizedReconnectOptions {
+  maxAttempts: number;
+  baseDelayMs: number;
+  maxDelayMs: number;
+}
+
+export class BitmexWsClient extends EventEmitter {
+  private readonly url: string;
+  private readonly pingIntervalMs: number;
+  private readonly pongTimeoutMs: number;
+  private readonly sendBufferLimit: number;
+  private readonly reconnectOptions: NormalizedReconnectOptions;
+
+  private ws: WebSocket | null = null;
+  private state: WsState = 'idle';
+  private sendBuffer: string[] = [];
+  private reconnectAttempts = 0;
+  private manualCloseRequested = false;
+
+  private pingTimer: NodeJS.Timeout | null = null;
+  private pongTimer: NodeJS.Timeout | null = null;
+  private reconnectTimer: NodeJS.Timeout | null = null;
+
+  private connectPromise: Promise<void> | null = null;
+  private resolveConnect?: () => void;
+  private rejectConnect?: (err: Error) => void;
+
+  private readonly log = createLogger('bitmex:ws');
+
+  constructor(opts: BitmexWsOptions = {}) {
+    super();
+
+    const {
+      isTest,
+      url,
+      pingIntervalMs = WS_PING_INTERVAL_MS,
+      pongTimeoutMs = WS_PONG_TIMEOUT_MS,
+      reconnect,
+      sendBufferLimit = WS_SEND_BUFFER_LIMIT,
+    } = opts;
+
+    const {
+      baseDelayMs = WS_RECONNECT_BASE_DELAY_MS,
+      maxDelayMs = WS_RECONNECT_MAX_DELAY_MS,
+      maxAttempts = WS_RECONNECT_MAX_ATTEMPTS,
+    } = reconnect ?? {};
+
+    this.url = url ?? (isTest ? BITMEX_WS_ENDPOINTS.testnet : BITMEX_WS_ENDPOINTS.mainnet);
+    this.pingIntervalMs = pingIntervalMs;
+    this.pongTimeoutMs = pongTimeoutMs;
+    this.sendBufferLimit = sendBufferLimit;
+    this.reconnectOptions = { baseDelayMs, maxDelayMs, maxAttempts } satisfies NormalizedReconnectOptions;
+  }
+
+  getState(): WsState {
+    return this.state;
+  }
+
+  isOpen(): boolean {
+    return this.ws?.readyState === WebSocket.OPEN;
+  }
+
+  async connect(): Promise<void> {
+    this.manualCloseRequested = false;
+
+    if (this.isOpen()) {
+      this.log.info('BitMEX WS already open', { url: this.url });
+      return;
+    }
+
+    if (!this.connectPromise) {
+      this.connectPromise = new Promise<void>((resolve, reject) => {
+        this.resolveConnect = resolve;
+        this.rejectConnect = reject;
+      });
+    }
+
+    if (this.state === 'connecting' || this.state === 'reconnecting') {
+      return this.connectPromise;
+    }
+
+    this.reconnectAttempts = 0;
+    this.openSocket('connecting');
+
+    return this.connectPromise;
+  }
+
+  async disconnect({ graceful = true }: { graceful?: boolean } = {}): Promise<void> {
+    this.manualCloseRequested = true;
+    this.clearReconnectTimer();
+    this.stopKeepalive();
+
+    if (!this.ws) {
+      this.log.info('BitMEX WS disconnect requested but no active socket');
+      if (this.connectPromise) {
+        this.rejectPendingConnect(new Error('BitMEX WS disconnected'));
+      }
+      this.transitionState('idle');
+      return;
+    }
+
+    const ws = this.ws;
+
+    if (ws.readyState === WebSocket.CLOSED) {
+      this.cleanupWebSocket(ws);
+      this.transitionState('idle');
+      this.manualCloseRequested = false;
+      this.rejectPendingConnect(new Error('BitMEX WS disconnected'));
+      return;
+    }
+
+    this.transitionState('closing');
+    this.log.info('BitMEX WS disconnect → %s', graceful ? 'graceful' : 'terminate');
+
+    await new Promise<void>((resolve) => {
+      const finalize = () => resolve();
+      ws.once('close', finalize);
+
+      try {
+        if (graceful) {
+          ws.close(1000, 'client-request');
+        } else {
+          ws.terminate();
+        }
+      } catch (err) {
+        this.log.warn('BitMEX WS disconnect error: %s', (err as Error).message);
+        resolve();
+      }
+    });
+  }
+
+  send(raw: string): void {
+    if (this.isOpen()) {
+      this.ws!.send(raw);
+      return;
+    }
+
+    if (this.sendBuffer.length >= this.sendBufferLimit) {
+      throw new ValidationError('BitMEX WS send buffer overflow', {
+        details: { limit: this.sendBufferLimit },
+      });
+    }
+
+    this.sendBuffer.push(raw);
+  }
+
+  // region: socket lifecycle -------------------------------------------------
+
+  protected openSocket(initialState: 'connecting' | 'reconnecting'): void {
+    this.clearReconnectTimer();
+    this.stopKeepalive();
+    this.cleanupWebSocket();
+
+    this.transitionState(initialState);
+    const attempt = this.reconnectAttempts + 1;
+    this.log.info('BitMEX WS connect attempt %d → %s', attempt, this.url);
+
+    const ws = new WebSocket(this.url);
+    this.ws = ws;
+
+    ws.on('open', this.handleOpen);
+    ws.on('message', this.handleMessage);
+    ws.on('pong', this.handlePong);
+    ws.on('error', this.handleError);
+    ws.on('close', this.handleClose);
+  }
+
+  private readonly handleOpen = (): void => {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+      return;
+    }
+
+    this.transitionState('open');
+    this.reconnectAttempts = 0;
+    this.manualCloseRequested = false;
+
+    this.log.info('BitMEX WS open');
+
+    this.startKeepalive();
+    this.flushSendBuffer();
+    this.resolvePendingConnect();
+
+    this.emit('open');
+  };
+
+  private readonly handleMessage = (data: RawData): void => {
+    const text = this.normalizeMessage(data);
+    this.emit('message', text);
+    this.bumpPongDeadline();
+  };
+
+  private readonly handlePong = (): void => {
+    this.bumpPongDeadline();
+  };
+
+  private readonly handleError = (err: Error): void => {
+    this.log.warn('BitMEX WS error: %s', err?.message ?? 'unknown');
+    this.emit('error', err);
+  };
+
+  private readonly handleClose = (code: number, reasonBuf: Buffer): void => {
+    const reason = reasonBuf?.toString('utf8') || undefined;
+
+    this.log.warn('BitMEX WS close', { code, reason });
+
+    this.stopKeepalive();
+    this.emit('close', { code, reason });
+
+    const ws = this.ws;
+    this.cleanupWebSocket(ws ?? undefined);
+
+    if (this.manualCloseRequested) {
+      this.manualCloseRequested = false;
+      this.transitionState('idle');
+      this.rejectPendingConnect(new Error('BitMEX WS disconnected'));
+      return;
+    }
+
+    this.scheduleReconnect(code, reason);
+  };
+
+  private cleanupWebSocket(socket?: WebSocket | null): void {
+    const ws = socket ?? this.ws;
+    if (!ws) {
+      this.ws = null;
+      return;
+    }
+
+    ws.off('open', this.handleOpen);
+    ws.off('message', this.handleMessage);
+    ws.off('pong', this.handlePong);
+    ws.off('error', this.handleError);
+    ws.off('close', this.handleClose);
+
+    if (!socket || socket === this.ws) {
+      this.ws = null;
+    }
+  }
+
+  // endregion
+
+  // region: buffering -------------------------------------------------------
+
+  private flushSendBuffer(): void {
+    if (!this.isOpen() || this.sendBuffer.length === 0) {
+      return;
+    }
+
+    const pending = this.sendBuffer.slice();
+    this.sendBuffer.length = 0;
+
+    for (let i = 0; i < pending.length; i += 1) {
+      const message = pending[i];
+      try {
+        this.ws!.send(message);
+      } catch (err) {
+        this.log.error('BitMEX WS flush error: %s', (err as Error).message);
+        this.sendBuffer = pending.slice(i);
+        break;
+      }
+    }
+  }
+
+  // endregion
+
+  // region: keepalive -------------------------------------------------------
+
+  private startKeepalive(): void {
+    this.stopKeepalive();
+
+    if (!this.isOpen()) {
+      return;
+    }
+
+    this.pingTimer = setInterval(() => {
+      if (this.ws?.readyState === WebSocket.OPEN) {
+        try {
+          this.ws.ping();
+        } catch (err) {
+          this.log.warn('BitMEX WS ping error: %s', (err as Error).message);
+        }
+      }
+
+      this.bumpPongDeadline();
+    }, this.pingIntervalMs);
+
+    this.bumpPongDeadline();
+  }
+
+  private stopKeepalive(): void {
+    if (this.pingTimer) {
+      clearInterval(this.pingTimer);
+      this.pingTimer = null;
+    }
+
+    if (this.pongTimer) {
+      clearTimeout(this.pongTimer);
+      this.pongTimer = null;
+    }
+  }
+
+  private bumpPongDeadline(): void {
+    if (!this.isOpen()) {
+      return;
+    }
+
+    if (this.pongTimer) {
+      clearTimeout(this.pongTimer);
+    }
+
+    this.pongTimer = setTimeout(() => {
+      this.handlePongTimeout();
+    }, this.pongTimeoutMs);
+  }
+
+  protected handlePongTimeout(): void {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+      return;
+    }
+
+    this.log.warn('BitMEX WS pong timeout — terminating connection');
+
+    try {
+      this.ws.terminate();
+    } catch (err) {
+      this.log.warn('BitMEX WS terminate error: %s', (err as Error).message);
+    }
+  }
+
+  // endregion
+
+  // region: reconnect -------------------------------------------------------
+
+  private scheduleReconnect(code?: number, reason?: string): void {
+    const error = fromWsClose({
+      code: code ?? 1006,
+      reason,
+      exchange: 'BitMEX',
+    });
+
+    this.reconnectAttempts += 1;
+
+    if (this.reconnectAttempts > this.reconnectOptions.maxAttempts) {
+      this.log.error('BitMEX WS reconnect attempts exceeded', {
+        attempts: this.reconnectAttempts,
+        code,
+        reason,
+      });
+
+      this.transitionState('idle');
+      this.rejectPendingConnect(error);
+      this.emit('error', error);
+      return;
+    }
+
+    const delay = this.computeReconnectDelay(this.reconnectAttempts);
+
+    this.transitionState('reconnecting');
+    this.log.warn('BitMEX WS reconnect in %dms (attempt %d)', delay, this.reconnectAttempts, {
+      code,
+      reason,
+    });
+
+    this.clearReconnectTimer();
+    this.reconnectTimer = setTimeout(() => {
+      this.openSocket('reconnecting');
+    }, delay);
+  }
+
+  private computeReconnectDelay(attempt: number): number {
+    const exponent = Math.max(0, attempt - 1);
+    const delay = this.reconnectOptions.baseDelayMs * 2 ** exponent;
+    return Math.min(this.reconnectOptions.maxDelayMs, delay);
+  }
+
+  protected clearReconnectTimer(): void {
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+  }
+
+  // endregion
+
+  private normalizeMessage(data: RawData): string {
+    if (typeof data === 'string') {
+      return data;
+    }
+
+    if (Array.isArray(data)) {
+      return Buffer.concat(data).toString('utf8');
+    }
+
+    if (data instanceof ArrayBuffer) {
+      return Buffer.from(data).toString('utf8');
+    }
+
+    return (data as Buffer).toString('utf8');
+  }
+
+  private resolvePendingConnect(): void {
+    if (this.resolveConnect) {
+      this.resolveConnect();
+    }
+
+    this.clearPendingConnect();
+  }
+
+  private rejectPendingConnect(err: Error): void {
+    if (this.rejectConnect) {
+      this.rejectConnect(err);
+    }
+
+    this.clearPendingConnect();
+  }
+
+  private clearPendingConnect(): void {
+    this.connectPromise = null;
+    this.resolveConnect = undefined;
+    this.rejectConnect = undefined;
+  }
+
+  private transitionState(next: WsState): void {
+    if (this.state === next) {
+      return;
+    }
+
+    this.state = next;
+    this.log.debug('BitMEX WS state → %s', next);
+  }
+}
+
+export interface BitmexWsClient {
+  on<U extends keyof BitmexWsEvents>(event: U, listener: BitmexWsEvents[U]): this;
+  once<U extends keyof BitmexWsEvents>(event: U, listener: BitmexWsEvents[U]): this;
+  off<U extends keyof BitmexWsEvents>(event: U, listener: BitmexWsEvents[U]): this;
+  emit<U extends keyof BitmexWsEvents>(event: U, ...args: Parameters<BitmexWsEvents[U]>): boolean;
+}

--- a/tests/ws/transport.test.ts
+++ b/tests/ws/transport.test.ts
@@ -1,0 +1,168 @@
+import { AddressInfo } from 'node:net';
+
+import { WebSocketServer } from 'ws';
+
+import { BitmexWsClient } from '../../src/cores/bitmex/transport/ws.js';
+import { ValidationError } from '../../src/infra/errors.js';
+
+jest.setTimeout(10_000);
+
+class TestBitmexWsClient extends BitmexWsClient {
+  public readonly openCalls: ('connecting' | 'reconnecting')[] = [];
+
+  protected override openSocket(state: 'connecting' | 'reconnecting'): void {
+    this.openCalls.push(state);
+
+    if (state === 'connecting') {
+      super.openSocket(state);
+      return;
+    }
+
+    this.clearReconnectTimer();
+  }
+
+  public triggerPongTimeout(): void {
+    this.handlePongTimeout();
+  }
+}
+
+describe('BitmexWsClient (transport)', () => {
+  let wss: WebSocketServer;
+  let url: string;
+
+  beforeEach(async () => {
+    wss = new WebSocketServer({ port: 0 });
+    await new Promise<void>((resolve) => wss.once('listening', resolve));
+    const address = wss.address() as AddressInfo;
+    url = `ws://127.0.0.1:${address.port}`;
+  });
+
+  afterEach(async () => {
+    for (const client of wss.clients) {
+      client.terminate();
+    }
+
+    await new Promise<void>((resolve) => wss.close(() => resolve()));
+  });
+
+  test('queues messages until open and flushes them on connect', async () => {
+    const received: string[] = [];
+    const messagePromise = new Promise<void>((resolve) => {
+      wss.once('connection', (socket) => {
+        socket.on('message', (payload) => {
+          received.push(payload.toString());
+          if (received.length === 2) {
+            resolve();
+          }
+        });
+      });
+    });
+
+    const client = new BitmexWsClient({
+      url,
+      pingIntervalMs: 5_000,
+      pongTimeoutMs: 5_000,
+      reconnect: { baseDelayMs: 50, maxDelayMs: 50, maxAttempts: 3 },
+    });
+
+    const openPromise = new Promise<void>((resolve) => client.once('open', resolve));
+
+    client.send('first');
+    client.send('second');
+
+    await client.connect();
+    await openPromise;
+    await messagePromise;
+
+    expect(received).toEqual(['first', 'second']);
+    expect(client.isOpen()).toBe(true);
+
+    await client.disconnect();
+  });
+
+  test('throws ValidationError when send buffer exceeds limit', () => {
+    const client = new BitmexWsClient({ url, sendBufferLimit: 2 });
+
+    client.send('one');
+    client.send('two');
+
+    expect(() => client.send('three')).toThrow(ValidationError);
+  });
+
+  test('reconnects after close and resets attempt counter', async () => {
+    const client = new BitmexWsClient({
+      url,
+      pingIntervalMs: 200,
+      pongTimeoutMs: 200,
+      reconnect: { baseDelayMs: 50, maxDelayMs: 50, maxAttempts: 5 },
+    });
+
+    client.on('error', () => {});
+
+    let openCount = 0;
+    const secondOpen = new Promise<void>((resolve) => {
+      client.on('open', () => {
+        openCount += 1;
+        if (openCount === 2) {
+          resolve();
+        }
+      });
+    });
+
+    wss.on('connection', (socket) => {
+      if (openCount === 0) {
+        setTimeout(() => socket.terminate(), 20);
+      }
+    });
+
+    await client.connect();
+    await secondOpen;
+
+    expect(client.getState()).toBe('open');
+    expect((client as any).reconnectAttempts).toBe(0);
+
+    await client.disconnect();
+  });
+
+  test('computes exponential backoff with cap', () => {
+    const client = new BitmexWsClient({
+      url,
+      reconnect: { baseDelayMs: 200, maxDelayMs: 1_000, maxAttempts: 12 },
+    });
+
+    const delays = Array.from({ length: 6 }, (_, idx) =>
+      (client as any).computeReconnectDelay(idx + 1) as number,
+    );
+
+    expect(delays).toEqual([200, 400, 800, 1_000, 1_000, 1_000]);
+  });
+
+  test('triggers reconnect on pong timeout', async () => {
+    const client = new TestBitmexWsClient({
+      url,
+      pingIntervalMs: 40,
+      pongTimeoutMs: 60,
+      reconnect: { baseDelayMs: 25, maxDelayMs: 25, maxAttempts: 4 },
+    });
+
+    client.on('error', () => {});
+
+    await client.connect();
+
+    const closeInfoPromise = new Promise<{ code: number; reason?: string }>((resolve) =>
+      client.once('close', resolve),
+    );
+
+    client.triggerPongTimeout();
+
+    const closeInfo = await closeInfoPromise;
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(closeInfo.code).toBe(1006);
+    expect(client.openCalls).toContain('reconnecting');
+    expect(client.getState()).toBe('reconnecting');
+
+    await client.disconnect();
+  });
+});


### PR DESCRIPTION
## Summary
- add a BitMEX WebSocket transport with keepalive ping/pong, send buffering, and exponential reconnect behaviour
- expose WebSocket timing and buffer constants alongside endpoint metadata
- cover the transport with ws-based integration tests and helpers while wiring the ws dependency

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68caaf8ff3e883209aa4cb52affde92b