### PR TITLE
Implement BitMEX trade channel with FIFO buffer

### DIFF
--- a/src/cores/bitmex/channelMessageHandlers/trade.ts
+++ b/src/cores/bitmex/channelMessageHandlers/trade.ts
@@ -1,30 +1,28 @@
-import { handleTradeInsert, handleTradeMessage, handleTradePartial } from '../channels/trade.js';
+import { handleTradeMessage } from '../channels/trade.js';
 
 import type { BitMex } from '../index.js';
-import type { BitMexChannelMessage, BitMexTrade } from '../types.js';
+import type { BitMexChannelMessage } from '../types.js';
 
-function forward(
-  core: BitMex,
-  action: BitMexChannelMessage<'trade'>['action'],
-  data: BitMexTrade[],
-): void {
+type TradeMessage = BitMexChannelMessage<'trade'>;
+
+function forward(core: BitMex, action: TradeMessage['action'], data: TradeMessage['data']): void {
   handleTradeMessage(core, { table: 'trade', action, data });
 }
 
 export const trade = {
-  partial(core: BitMex, data: BitMexTrade[]) {
-    handleTradePartial(core, data);
+  partial(core: BitMex, data: TradeMessage['data']) {
+    forward(core, 'partial', data);
   },
 
-  insert(core: BitMex, data: BitMexTrade[]) {
-    handleTradeInsert(core, data);
+  insert(core: BitMex, data: TradeMessage['data']) {
+    forward(core, 'insert', data);
   },
 
-  update(core: BitMex, data: BitMexTrade[]) {
+  update(core: BitMex, data: TradeMessage['data']) {
     forward(core, 'update', data);
   },
 
-  delete(core: BitMex, data: BitMexTrade[]) {
+  delete(core: BitMex, data: TradeMessage['data']) {
     forward(core, 'delete', data);
   },
 };

--- a/src/cores/bitmex/channelMessageHandlers/trade.ts
+++ b/src/cores/bitmex/channelMessageHandlers/trade.ts
@@ -1,20 +1,30 @@
+import { handleTradeInsert, handleTradeMessage, handleTradePartial } from '../channels/trade.js';
+
 import type { BitMex } from '../index.js';
-import type { BitMexTrade } from '../types.js';
+import type { BitMexChannelMessage, BitMexTrade } from '../types.js';
+
+function forward(
+  core: BitMex,
+  action: BitMexChannelMessage<'trade'>['action'],
+  data: BitMexTrade[],
+): void {
+  handleTradeMessage(core, { table: 'trade', action, data });
+}
 
 export const trade = {
-  partial(_core: BitMex, _data: BitMexTrade[]) {
-    throw 'not implemented';
+  partial(core: BitMex, data: BitMexTrade[]) {
+    handleTradePartial(core, data);
   },
 
-  insert(_core: BitMex, _data: BitMexTrade[]) {
-    throw 'not implemented';
+  insert(core: BitMex, data: BitMexTrade[]) {
+    handleTradeInsert(core, data);
   },
 
-  update(_core: BitMex, _data: BitMexTrade[]) {
-    throw 'not implemented';
+  update(core: BitMex, data: BitMexTrade[]) {
+    forward(core, 'update', data);
   },
 
-  delete(_core: BitMex, _data: BitMexTrade[]) {
-    throw 'not implemented';
+  delete(core: BitMex, data: BitMexTrade[]) {
+    forward(core, 'delete', data);
   },
 };

--- a/src/cores/bitmex/channels/instrument.ts
+++ b/src/cores/bitmex/channels/instrument.ts
@@ -1,6 +1,7 @@
 import { Instrument } from '../../../domain/instrument.js';
 import type { InstrumentInit } from '../../../domain/instrument.js';
 import { mapSymbolNativeToUni } from '../../../utils/symbolMapping.js';
+import { TRADE_BUFFER_DEFAULT } from '../constants.js';
 
 import type { BitMex } from '../index.js';
 import type {
@@ -105,7 +106,7 @@ export function handleInstrumentDelete(core: BitMex, data: BitMexInstrument[]): 
 function createInstrument(core: BitMex, raw: BitMexInstrument): Instrument {
   const init = buildInstrumentUpdate(core, raw);
 
-  return new Instrument(init);
+  return new Instrument(init, { tradeBufferSize: TRADE_BUFFER_DEFAULT });
 }
 
 function buildInstrumentUpdate(core: BitMex, raw: BitMexInstrument): InstrumentInit {

--- a/src/cores/bitmex/channels/trade.ts
+++ b/src/cores/bitmex/channels/trade.ts
@@ -1,0 +1,233 @@
+import { createLogger } from '../../../infra/logger.js';
+import { mapSymbolNativeToUni } from '../../../utils/symbolMapping.js';
+
+import { TRADE_BUFFER_MAX, TRADE_BUFFER_MIN } from '../constants.js';
+
+import type { Instrument } from '../../../domain/instrument.js';
+import type { BitmexTrade, BitmexTradeRaw } from '../../../types/bitmex.js';
+import type { BitMex } from '../index.js';
+import type { BitMexChannelMessage } from '../types.js';
+
+const log = createLogger('bitmex:trade');
+
+export function handleTradeMessage(core: BitMex, message: BitMexChannelMessage<'trade'>): void {
+  const { action, data } = message;
+
+  switch (action) {
+    case 'partial':
+      handleTradePartial(core, data);
+      break;
+    case 'insert':
+      handleTradeInsert(core, data);
+      break;
+    default:
+      log.debug('BitMEX trade action ignored: %s', action, { action });
+      break;
+  }
+}
+
+export function handleTradePartial(core: BitMex, rows: BitmexTradeRaw[]): void {
+  if (!Array.isArray(rows) || rows.length === 0) {
+    return;
+  }
+
+  for (const [symbol, batch] of groupBySymbol(rows)) {
+    const instrument = resolveInstrument(core, symbol);
+
+    if (!instrument) {
+      log.debug('BitMEX trade partial: instrument not found for %s', symbol);
+      continue;
+    }
+
+    const { trades, skipped } = normalizeBatch(batch);
+
+    if (trades.length === 0) {
+      log.debug('BitMEX trade partial: no valid trades for %s', symbol, { skipped });
+      continue;
+    }
+
+    const capacity = clampBufferSize(instrument.tradeBufferSize);
+    const limited = trades.length > capacity ? trades.slice(trades.length - capacity) : trades;
+    const trimmed = trades.length - limited.length;
+    const result = instrument.trades.push(limited, { reset: true });
+
+    log.info('BitMEX trade partial snapshot for %s', symbol, {
+      total: batch.length,
+      accepted: trades.length,
+      stored: limited.length,
+      skipped,
+      trimmed,
+    });
+
+    if (trimmed > 0 || result.dropped > 0) {
+      log.warn('BitMEX trade partial trimmed buffer for %s', symbol, {
+        trimmed,
+        dropped: result.dropped,
+      });
+    }
+  }
+}
+
+export function handleTradeInsert(core: BitMex, rows: BitmexTradeRaw[]): void {
+  if (!Array.isArray(rows) || rows.length === 0) {
+    return;
+  }
+
+  for (const [symbol, batch] of groupBySymbol(rows)) {
+    const instrument = resolveInstrument(core, symbol);
+
+    if (!instrument) {
+      log.debug('BitMEX trade insert: instrument not found for %s', symbol);
+      continue;
+    }
+
+    const { trades, skipped } = normalizeBatch(batch);
+
+    if (trades.length === 0) {
+      if (skipped > 0) {
+        log.debug('BitMEX trade insert: skipped invalid trades for %s', symbol, { skipped });
+      }
+      continue;
+    }
+
+    const result = instrument.trades.push(trades);
+
+    log.debug('BitMEX trade insert for %s', symbol, {
+      total: batch.length,
+      accepted: trades.length,
+      skipped,
+    });
+
+    if (result.dropped > 0) {
+      log.warn('BitMEX trade buffer overflow for %s', symbol, { dropped: result.dropped });
+    }
+  }
+}
+
+function groupBySymbol(rows: BitmexTradeRaw[]): Map<string, BitmexTradeRaw[]> {
+  const grouped = new Map<string, BitmexTradeRaw[]>();
+
+  for (const row of rows) {
+    const symbol = typeof row?.symbol === 'string' ? row.symbol.trim() : '';
+
+    if (!symbol) {
+      continue;
+    }
+
+    if (!grouped.has(symbol)) {
+      grouped.set(symbol, []);
+    }
+
+    grouped.get(symbol)!.push(row);
+  }
+
+  return grouped;
+}
+
+function resolveInstrument(core: BitMex, symbol: string): Instrument | undefined {
+  const byNative = core.getInstrumentByNative(symbol);
+
+  if (byNative) {
+    return byNative;
+  }
+
+  if (!core.symbolMappingEnabled) {
+    return undefined;
+  }
+
+  const unified = mapSymbolNativeToUni(symbol, { enabled: core.symbolMappingEnabled });
+
+  if (!unified) {
+    return undefined;
+  }
+
+  return core.instruments.get(unified);
+}
+
+function normalizeBatch(rows: BitmexTradeRaw[]): { trades: BitmexTrade[]; skipped: number } {
+  const normalized: BitmexTrade[] = [];
+  let skipped = 0;
+
+  for (const row of rows) {
+    const trade = normalizeTrade(row);
+
+    if (!trade) {
+      skipped += 1;
+      continue;
+    }
+
+    normalized.push(trade);
+  }
+
+  normalized.sort((a, b) => a.ts - b.ts);
+
+  return { trades: normalized, skipped };
+}
+
+function normalizeTrade(raw: BitmexTradeRaw): BitmexTrade | null {
+  if (!raw || typeof raw.timestamp !== 'string' || typeof raw.side !== 'string') {
+    return null;
+  }
+
+  const ts = Date.parse(raw.timestamp);
+
+  if (!Number.isFinite(ts)) {
+    return null;
+  }
+
+  let price: number | undefined;
+
+  if (typeof raw.price === 'number' && Number.isFinite(raw.price)) {
+    price = raw.price;
+  } else if (
+    typeof raw.foreignNotional === 'number' &&
+    Number.isFinite(raw.foreignNotional) &&
+    typeof raw.size === 'number' &&
+    Number.isFinite(raw.size) &&
+    raw.size !== 0
+  ) {
+    price = raw.foreignNotional / raw.size;
+  }
+
+  if (price === undefined || !Number.isFinite(price)) {
+    return null;
+  }
+
+  const side = raw.side.toLowerCase() === 'sell' ? 'sell' : 'buy';
+
+  const trade: BitmexTrade = {
+    ts,
+    side,
+    price,
+  };
+
+  if (typeof raw.size === 'number' && Number.isFinite(raw.size)) {
+    trade.size = raw.size;
+  }
+
+  if (raw.trdMatchID) {
+    trade.id = raw.trdMatchID;
+  }
+
+  if (typeof raw.foreignNotional === 'number' && Number.isFinite(raw.foreignNotional)) {
+    trade.foreignNotional = raw.foreignNotional;
+  }
+
+  return trade;
+}
+
+function clampBufferSize(size: number): number {
+  if (!Number.isFinite(size)) {
+    return TRADE_BUFFER_MIN;
+  }
+
+  if (size < TRADE_BUFFER_MIN) {
+    return TRADE_BUFFER_MIN;
+  }
+
+  if (size > TRADE_BUFFER_MAX) {
+    return TRADE_BUFFER_MAX;
+  }
+
+  return Math.floor(size);
+}

--- a/src/cores/bitmex/constants.ts
+++ b/src/cores/bitmex/constants.ts
@@ -29,6 +29,10 @@ export const WS_RECONNECT_BASE_DELAY_MS = 200; // min 200ms
 export const WS_RECONNECT_MAX_DELAY_MS = 10 * 60 * 1000; // 10min
 export const WS_SEND_BUFFER_LIMIT = 1_000;
 
+export const TRADE_BUFFER_DEFAULT = 1_000;
+export const TRADE_BUFFER_MIN = 1;
+export const TRADE_BUFFER_MAX = 10_000;
+
 export const BITMEX_REST_ENDPOINTS = {
   testnet: 'https://testnet.bitmex.com/api/v1',
   mainnet: 'https://www.bitmex.com/api/v1',

--- a/src/cores/bitmex/types.ts
+++ b/src/cores/bitmex/types.ts
@@ -3,6 +3,7 @@ import type {
   BITMEX_PUBLIC_CHANNELS,
   BITMEX_CHANNELS,
 } from './constants.js';
+import type { BitmexTradeRaw } from '../../types/bitmex.js';
 
 export type BitMexWelcomeMessage = {
   info: string;
@@ -245,18 +246,11 @@ export type BitMexInstrument = {
   timestamp?: string;
 };
 
-export type BitMexTrade = {
-  trdMatchID: string;
-  symbol: string;
-  side: BitMexSide;
-  size: number;
-  price: number;
+export type BitMexTrade = BitmexTradeRaw & {
   tickDirection?: BitMexTickDirection;
   trdType?: BitMexTradeType;
   grossValue?: number;
   homeNotional?: number;
-  foreignNotional?: number;
-  timestamp: string;
 };
 
 export type BitMexLiquidation = {

--- a/src/domain/instrument.ts
+++ b/src/domain/instrument.ts
@@ -1,5 +1,7 @@
 import { EventEmitter } from 'node:events';
 
+import type { Side } from '../types.js';
+
 export type Nullable<T> = T | null | undefined;
 
 export type InstrumentStatus =
@@ -50,7 +52,114 @@ export type InstrumentUpdate = Partial<InstrumentShape> & {
   priceFilters?: InstrumentPriceFilters;
 };
 
-export type InstrumentChanges = InstrumentUpdate;
+export type InstrumentTrade = {
+  ts: number;
+  side: Side;
+  price: number;
+  size?: number;
+  id?: string;
+  foreignNotional?: number;
+};
+
+export type InstrumentTradePushOptions = {
+  reset?: boolean;
+};
+
+export type InstrumentTradePushResult = {
+  inserted: InstrumentTrade[];
+  dropped: number;
+  reset: boolean;
+};
+
+type InstrumentTradeInsertMeta = {
+  reset: boolean;
+  dropped: number;
+};
+
+type InstrumentTradeInsertListener = (
+  trades: InstrumentTrade[],
+  meta: InstrumentTradeInsertMeta,
+) => void;
+
+export class InstrumentTradesBuffer {
+  #buffer: InstrumentTrade[] = [];
+  #capacity: number;
+  #onInsert: InstrumentTradeInsertListener;
+
+  constructor(capacity: number, onInsert: InstrumentTradeInsertListener) {
+    this.#capacity = InstrumentTradesBuffer.#normalizeCapacity(capacity);
+    this.#onInsert = onInsert;
+  }
+
+  static #normalizeCapacity(size: number): number {
+    if (!Number.isFinite(size) || size <= 0) {
+      return 1;
+    }
+
+    return Math.max(1, Math.floor(size));
+  }
+
+  get capacity(): number {
+    return this.#capacity;
+  }
+
+  get length(): number {
+    return this.#buffer.length;
+  }
+
+  push(
+    batch: InstrumentTrade[],
+    options: InstrumentTradePushOptions = {},
+  ): InstrumentTradePushResult {
+    const { reset = false } = options;
+
+    if (reset) {
+      this.#buffer = [];
+    }
+
+    if (!Array.isArray(batch) || batch.length === 0) {
+      return { inserted: [], dropped: 0, reset };
+    }
+
+    const inserted: InstrumentTrade[] = [];
+
+    for (const trade of batch) {
+      if (!trade) {
+        continue;
+      }
+
+      const normalized: InstrumentTrade = Object.freeze({ ...trade });
+      this.#buffer.push(normalized);
+      inserted.push(normalized);
+    }
+
+    let dropped = 0;
+
+    if (this.#buffer.length > this.#capacity) {
+      dropped = this.#buffer.length - this.#capacity;
+      this.#buffer.splice(0, dropped);
+    }
+
+    if (inserted.length > 0) {
+      this.#onInsert(inserted, { reset, dropped });
+    }
+
+    return { inserted, dropped, reset };
+  }
+
+  toArray(): InstrumentTrade[] {
+    return this.#buffer.slice();
+  }
+}
+
+export type InstrumentChanges = InstrumentUpdate & {
+  trades?: InstrumentTrade[];
+};
+
+export type InstrumentOptions = {
+  tradeBufferSize?: number;
+  tradeEventEnabled?: boolean;
+};
 
 const WRITABLE_FIELDS: (keyof InstrumentShape)[] = [
   'symbolNative',
@@ -78,6 +187,24 @@ const WRITABLE_FIELDS: (keyof InstrumentShape)[] = [
 ];
 
 export class Instrument extends EventEmitter {
+  static readonly DEFAULT_TRADE_BUFFER_SIZE = 1_000;
+
+  static normalizeTradeBufferSize(size?: number): number {
+    if (!Number.isFinite(size)) {
+      return Instrument.DEFAULT_TRADE_BUFFER_SIZE;
+    }
+
+    const normalized = Math.floor(size as number);
+
+    if (!Number.isFinite(normalized) || normalized <= 0) {
+      return Instrument.DEFAULT_TRADE_BUFFER_SIZE;
+    }
+
+    return Math.max(1, normalized);
+  }
+
+  #tradeEventEnabled: boolean;
+
   public symbolNative: string;
   public symbolUni: string;
   public status?: Nullable<InstrumentStatus>;
@@ -101,10 +228,15 @@ export class Instrument extends EventEmitter {
   public expiry?: Nullable<string>;
   public timestamp?: Nullable<string>;
   public priceFilters: InstrumentPriceFilters;
+  public readonly trades: InstrumentTradesBuffer;
 
   override on(
     event: 'update',
     listener: (instrument: Instrument, changes: InstrumentChanges) => void,
+  ): this;
+  override on(
+    event: 'trade',
+    listener: (instrument: Instrument, trades: InstrumentTrade[]) => void,
   ): this;
   override on(event: string | symbol, listener: (...args: any[]) => void): this;
   override on(event: string | symbol, listener: (...args: any[]) => void): this {
@@ -115,6 +247,10 @@ export class Instrument extends EventEmitter {
     event: 'update',
     listener: (instrument: Instrument, changes: InstrumentChanges) => void,
   ): this;
+  override once(
+    event: 'trade',
+    listener: (instrument: Instrument, trades: InstrumentTrade[]) => void,
+  ): this;
   override once(event: string | symbol, listener: (...args: any[]) => void): this;
   override once(event: string | symbol, listener: (...args: any[]) => void): this {
     return super.once(event, listener);
@@ -124,25 +260,70 @@ export class Instrument extends EventEmitter {
     event: 'update',
     listener: (instrument: Instrument, changes: InstrumentChanges) => void,
   ): this;
+  override off(
+    event: 'trade',
+    listener: (instrument: Instrument, trades: InstrumentTrade[]) => void,
+  ): this;
   override off(event: string | symbol, listener: (...args: any[]) => void): this;
   override off(event: string | symbol, listener: (...args: any[]) => void): this {
     return super.off(event, listener);
   }
 
   override emit(event: 'update', instrument: Instrument, changes: InstrumentChanges): boolean;
+  override emit(event: 'trade', instrument: Instrument, trades: InstrumentTrade[]): boolean;
   override emit(event: string | symbol, ...args: any[]): boolean;
   override emit(event: string | symbol, ...args: any[]): boolean {
     return super.emit(event, ...args);
   }
 
-  constructor(data: InstrumentInit) {
+  constructor(data: InstrumentInit, options: InstrumentOptions = {}) {
     super();
+
+    const { tradeBufferSize, tradeEventEnabled } = options;
+    const bufferSize = Instrument.normalizeTradeBufferSize(tradeBufferSize);
 
     this.symbolNative = data.symbolNative;
     this.symbolUni = data.symbolUni;
     this.priceFilters = {};
+    this.trades = new InstrumentTradesBuffer(bufferSize, (trades, meta) =>
+      this.#handleTradesInserted(trades, meta),
+    );
+    this.#tradeEventEnabled = tradeEventEnabled ?? false;
 
     this.applyUpdate(data, { emit: false });
+  }
+
+  #handleTradesInserted(trades: InstrumentTrade[], _meta: InstrumentTradeInsertMeta): void {
+    if (trades.length === 0) {
+      return;
+    }
+
+    const changes: InstrumentChanges = { trades };
+    this.emit('update', this, changes);
+
+    if (this.#tradeEventEnabled) {
+      this.emit('trade', this, trades);
+    }
+  }
+
+  get tradeBufferSize(): number {
+    return this.trades.capacity;
+  }
+
+  get tradeEventEnabled(): boolean {
+    return this.#tradeEventEnabled;
+  }
+
+  setTradeEventEnabled(enabled: boolean): void {
+    this.#tradeEventEnabled = Boolean(enabled);
+  }
+
+  enableTradeEvents(): void {
+    this.setTradeEventEnabled(true);
+  }
+
+  disableTradeEvents(): void {
+    this.setTradeEventEnabled(false);
   }
 
   applyUpdate(update: InstrumentUpdate, options: { emit?: boolean } = {}): boolean {

--- a/src/types/bitmex.ts
+++ b/src/types/bitmex.ts
@@ -1,0 +1,20 @@
+import type { Side } from '../types.js';
+
+export type BitmexTradeRaw = {
+  symbol: string;
+  side: 'Buy' | 'Sell';
+  size?: number;
+  price?: number;
+  foreignNotional?: number;
+  timestamp: string;
+  trdMatchID?: string;
+};
+
+export type BitmexTrade = {
+  ts: number;
+  side: Side;
+  price: number;
+  size?: number;
+  id?: string;
+  foreignNotional?: number;
+};

--- a/src/types/bitmex.ts
+++ b/src/types/bitmex.ts
@@ -10,7 +10,7 @@ export type BitmexTradeRaw = {
   trdMatchID?: string;
 };
 
-export type BitmexTrade = {
+export type Trade = {
   ts: number;
   side: Side;
   price: number;
@@ -18,3 +18,5 @@ export type BitmexTrade = {
   id?: string;
   foreignNotional?: number;
 };
+
+export type BitmexTrade = Trade;

--- a/tests/bitmex/trade.test.ts
+++ b/tests/bitmex/trade.test.ts
@@ -1,0 +1,245 @@
+import { ExchangeHub } from '../../src/ExchangeHub.js';
+import { handleInstrumentPartial } from '../../src/cores/bitmex/channels/instrument.js';
+import { handleTradeInsert, handleTradePartial } from '../../src/cores/bitmex/channels/trade.js';
+import { TRADE_BUFFER_DEFAULT } from '../../src/cores/bitmex/constants.js';
+
+import type { BitMex } from '../../src/cores/bitmex/index.js';
+import type { BitMexInstrument } from '../../src/cores/bitmex/types.js';
+import type { BitmexTradeRaw } from '../../src/types/bitmex.js';
+import type { Settings } from '../../src/types.js';
+
+class FakeWebSocket {
+  public readonly url: string;
+  public onmessage: ((event: { data: unknown }) => void) | null = null;
+  #listeners = new Map<string, Set<(...args: unknown[]) => void>>();
+
+  constructor(url: string) {
+    this.url = url;
+  }
+
+  addEventListener(event: string, listener: (...args: unknown[]) => void): void {
+    if (!this.#listeners.has(event)) {
+      this.#listeners.set(event, new Set());
+    }
+
+    this.#listeners.get(event)!.add(listener);
+  }
+
+  removeEventListener(event: string, listener: (...args: unknown[]) => void): void {
+    this.#listeners.get(event)?.delete(listener);
+  }
+
+  send(_data: string): void {}
+
+  close(): void {
+    this.#emit('close');
+  }
+
+  simulateOpen(): void {
+    this.#emit('open');
+  }
+
+  simulateMessage(data: unknown): void {
+    this.onmessage?.({ data });
+    this.#emit('message', { data });
+  }
+
+  #emit(event: string, ...args: unknown[]): void {
+    const handler = (this as any)[`on${event}`];
+    if (typeof handler === 'function') {
+      handler(...args);
+    }
+
+    for (const listener of this.#listeners.get(event) ?? []) {
+      listener(...args);
+    }
+  }
+}
+
+const ORIGINAL_WEBSOCKET = (globalThis as any).WebSocket;
+
+beforeAll(() => {
+  (globalThis as any).WebSocket = FakeWebSocket;
+});
+
+afterAll(() => {
+  (globalThis as any).WebSocket = ORIGINAL_WEBSOCKET;
+});
+
+const INSTRUMENT_FIXTURE: BitMexInstrument[] = [
+  {
+    symbol: 'XBTUSD',
+    state: 'Open',
+    typ: 'FFWCSX',
+    quoteCurrency: 'USD',
+    underlying: 'XBT',
+    lotSize: 100,
+    tickSize: 0.5,
+    lastPrice: 50_000,
+    timestamp: '2024-01-01T00:00:00.000Z',
+  },
+];
+
+function createHub(settings: Partial<Settings> = {}) {
+  const hub = new ExchangeHub('BitMex', { isTest: true, ...settings });
+  const core = hub.Core as BitMex;
+
+  return { hub, core };
+}
+
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function createTrade(
+  symbol: string,
+  options: {
+    index: number;
+    baseTime: number;
+    side?: 'Buy' | 'Sell';
+    price?: number;
+    size?: number;
+  },
+): BitmexTradeRaw {
+  const { index, baseTime, side, price, size } = options;
+  const ts = new Date(baseTime + index * 1_000).toISOString();
+
+  return {
+    symbol,
+    side: side ?? (index % 2 === 0 ? 'Buy' : 'Sell'),
+    price: price ?? 50_000 + index,
+    size: size ?? 10,
+    timestamp: ts,
+    trdMatchID: `${symbol}-${index}`,
+  };
+}
+
+describe('BitMEX trade channel', () => {
+  test('partial snapshot keeps only the newest trades within the buffer', () => {
+    const { hub, core } = createHub();
+
+    handleInstrumentPartial(core, clone(INSTRUMENT_FIXTURE));
+
+    const instrument = hub.instruments.get('btcusdt');
+    expect(instrument).toBeDefined();
+
+    const baseTime = Date.parse('2024-01-01T00:00:00.000Z');
+    const total = TRADE_BUFFER_DEFAULT + 200;
+    const trades: BitmexTradeRaw[] = Array.from({ length: total }, (_, index) =>
+      createTrade('XBTUSD', { index, baseTime }),
+    );
+
+    handleTradePartial(core, trades);
+
+    const snapshot = instrument!.trades.toArray();
+    expect(snapshot).toHaveLength(TRADE_BUFFER_DEFAULT);
+
+    const expectedStart = total - TRADE_BUFFER_DEFAULT;
+    expect(snapshot[0]?.id).toBe(`XBTUSD-${expectedStart}`);
+    expect(snapshot[snapshot.length - 1]?.id).toBe(`XBTUSD-${total - 1}`);
+
+    for (let i = 1; i < snapshot.length; i += 1) {
+      expect(snapshot[i].ts).toBeGreaterThanOrEqual(snapshot[i - 1].ts);
+    }
+  });
+
+  test('insert batches are ordered by timestamp and extend the buffer', () => {
+    const { hub, core } = createHub();
+    handleInstrumentPartial(core, clone(INSTRUMENT_FIXTURE));
+
+    const instrument = hub.instruments.get('btcusdt');
+    expect(instrument).toBeDefined();
+
+    const baseTime = Date.parse('2024-01-01T00:00:00.000Z');
+    handleTradePartial(core, [createTrade('XBTUSD', { index: 0, baseTime })]);
+
+    const insertBatch: BitmexTradeRaw[] = [
+      createTrade('XBTUSD', { index: 3, baseTime, price: 50_003 }),
+      createTrade('XBTUSD', { index: 2, baseTime, price: 50_002 }),
+      createTrade('XBTUSD', { index: 4, baseTime, price: 50_004 }),
+    ];
+
+    handleTradeInsert(core, insertBatch);
+
+    const snapshot = instrument!.trades.toArray();
+    expect(snapshot.map((trade) => trade.id)).toEqual([
+      'XBTUSD-0',
+      'XBTUSD-2',
+      'XBTUSD-3',
+      'XBTUSD-4',
+    ]);
+
+    for (let i = 1; i < snapshot.length; i += 1) {
+      expect(snapshot[i].ts).toBeGreaterThanOrEqual(snapshot[i - 1].ts);
+    }
+  });
+
+  test('emits update and trade events with inserted batches', () => {
+    const { hub, core } = createHub();
+    handleInstrumentPartial(core, clone(INSTRUMENT_FIXTURE));
+
+    const instrument = hub.instruments.get('btcusdt');
+    expect(instrument).toBeDefined();
+
+    const baseTime = Date.parse('2024-01-01T00:00:00.000Z');
+    handleTradePartial(core, [createTrade('XBTUSD', { index: 0, baseTime })]);
+
+    instrument!.setTradeEventEnabled(true);
+
+    const updateListener = jest.fn();
+    const tradeListener = jest.fn();
+    instrument!.on('update', updateListener);
+    instrument!.on('trade', tradeListener);
+
+    const insertBatch: BitmexTradeRaw[] = [
+      createTrade('XBTUSD', { index: 5, baseTime }),
+      createTrade('XBTUSD', { index: 6, baseTime }),
+    ];
+
+    handleTradeInsert(core, insertBatch);
+
+    expect(updateListener).toHaveBeenCalledTimes(1);
+    expect(tradeListener).toHaveBeenCalledTimes(1);
+
+    const [, changes] = updateListener.mock.calls[0];
+    expect(changes.trades).toBeDefined();
+    expect(changes.trades).toHaveLength(2);
+    expect(changes.trades?.map((trade) => trade.id)).toEqual(['XBTUSD-5', 'XBTUSD-6']);
+
+    const [, tradePayload] = tradeListener.mock.calls[0];
+    expect(tradePayload).toEqual(changes.trades);
+  });
+
+  test('works with symbol mapping enabled and disabled', () => {
+    const { hub: mappedHub, core: mappedCore } = createHub({ symbolMappingEnabled: true });
+    handleInstrumentPartial(mappedCore, clone(INSTRUMENT_FIXTURE));
+
+    const mappedInstrumentNative = mappedCore.getInstrumentByNative('XBTUSD');
+    expect(mappedInstrumentNative).toBeDefined();
+    expect(mappedHub.instruments.get('btcusdt')).toBe(mappedInstrumentNative);
+
+    handleTradeInsert(mappedCore, [
+      createTrade('XBTUSD', {
+        index: 1,
+        baseTime: Date.parse('2024-01-01T00:00:00.000Z'),
+      }),
+    ]);
+    expect(mappedInstrumentNative!.trades.toArray()).toHaveLength(1);
+
+    const { hub: nativeHub, core: nativeCore } = createHub({ symbolMappingEnabled: false });
+    handleInstrumentPartial(nativeCore, clone(INSTRUMENT_FIXTURE));
+
+    expect(nativeHub.instruments.get('btcusdt')).toBeUndefined();
+    const nativeInstrument = nativeCore.getInstrumentByNative('XBTUSD');
+    expect(nativeInstrument).toBeDefined();
+
+    handleTradeInsert(nativeCore, [
+      createTrade('XBTUSD', {
+        index: 2,
+        baseTime: Date.parse('2024-01-01T00:00:00.000Z'),
+      }),
+    ]);
+
+    expect(nativeInstrument!.trades.toArray()).toHaveLength(1);
+  });
+});

--- a/tests/ws/trade.smoke.test.ts
+++ b/tests/ws/trade.smoke.test.ts
@@ -133,6 +133,9 @@ describe('BitMEX trade channel smoke test', () => {
 
     socket!.simulateMessage(partialMessage);
 
+    expect(updates).toHaveLength(0);
+    expect(instrument!.trades.toArray()).toHaveLength(3);
+
     const insertMessage: BitMexChannelMessage<'trade'> = {
       table: 'trade',
       action: 'insert',
@@ -148,7 +151,7 @@ describe('BitMEX trade channel smoke test', () => {
     const uniqueIds = Array.from(new Set(ids));
 
     expect(uniqueIds).toEqual(['trade-0', 'trade-1', 'trade-2', 'trade-3', 'trade-4']);
-    expect(updates.length).toBeGreaterThanOrEqual(2);
+    expect(updates).toEqual([snapshot.length]);
 
     await hub.disconnect();
   });

--- a/tests/ws/trade.smoke.test.ts
+++ b/tests/ws/trade.smoke.test.ts
@@ -1,0 +1,155 @@
+import type { BitMexChannelMessage } from '../../src/cores/bitmex/types.js';
+
+import { ExchangeHub } from '../../src/ExchangeHub.js';
+import { handleInstrumentPartial } from '../../src/cores/bitmex/channels/instrument.js';
+import { TRADE_BUFFER_DEFAULT } from '../../src/cores/bitmex/constants.js';
+
+import type { BitMex } from '../../src/cores/bitmex/index.js';
+import type { BitMexInstrument } from '../../src/cores/bitmex/types.js';
+import type { BitmexTradeRaw } from '../../src/types/bitmex.js';
+
+class ControlledWebSocket {
+  static instances: ControlledWebSocket[] = [];
+
+  public readonly url: string;
+  public onmessage: ((event: { data: unknown }) => void) | null = null;
+  public onopen: (() => void) | null = null;
+  public onerror: ((err: unknown) => void) | null = null;
+  public onclose: ((event?: { code?: number; reason?: string }) => void) | null = null;
+
+  #listeners = new Map<string, Set<(...args: unknown[]) => void>>();
+
+  constructor(url: string) {
+    this.url = url;
+    ControlledWebSocket.instances.push(this);
+  }
+
+  addEventListener(event: string, listener: (...args: unknown[]) => void): void {
+    if (!this.#listeners.has(event)) {
+      this.#listeners.set(event, new Set());
+    }
+
+    this.#listeners.get(event)!.add(listener);
+  }
+
+  removeEventListener(event: string, listener: (...args: unknown[]) => void): void {
+    this.#listeners.get(event)?.delete(listener);
+  }
+
+  send(_data: string): void {}
+
+  close(): void {
+    this.#emit('close', { code: 1000, reason: 'client-request' });
+  }
+
+  simulateOpen(): void {
+    this.#emit('open');
+  }
+
+  simulateMessage(message: BitMexChannelMessage<any>): void {
+    const payload = JSON.stringify(message);
+    this.onmessage?.({ data: payload });
+    this.#emit('message', { data: payload });
+  }
+
+  #emit(event: string, ...args: unknown[]): void {
+    const handler = (this as any)[`on${event}`];
+    if (typeof handler === 'function') {
+      handler(...args);
+    }
+
+    for (const listener of this.#listeners.get(event) ?? []) {
+      listener(...args);
+    }
+  }
+}
+
+const ORIGINAL_WEBSOCKET = (globalThis as any).WebSocket;
+
+beforeAll(() => {
+  (globalThis as any).WebSocket = ControlledWebSocket;
+});
+
+afterAll(() => {
+  (globalThis as any).WebSocket = ORIGINAL_WEBSOCKET;
+});
+
+afterEach(() => {
+  ControlledWebSocket.instances = [];
+});
+
+const INSTRUMENT_SNAPSHOT: BitMexInstrument[] = [
+  {
+    symbol: 'XBTUSD',
+    state: 'Open',
+    typ: 'FFWCSX',
+    quoteCurrency: 'USD',
+    underlying: 'XBT',
+    lotSize: 100,
+    tickSize: 0.5,
+    lastPrice: 50_000,
+    timestamp: '2024-01-01T00:00:00.000Z',
+  },
+];
+
+function createTrade(index: number): BitmexTradeRaw {
+  return {
+    symbol: 'XBTUSD',
+    side: index % 2 === 0 ? 'Buy' : 'Sell',
+    price: 50_000 + index,
+    size: 5,
+    timestamp: new Date(Date.parse('2024-01-01T00:00:00.000Z') + index * 1_000).toISOString(),
+    trdMatchID: `trade-${index}`,
+  };
+}
+
+describe('BitMEX trade channel smoke test', () => {
+  test('processes partial and insert messages through mock WebSocket', async () => {
+    const hub = new ExchangeHub('BitMex', { isTest: true });
+    const core = hub.Core as BitMex;
+
+    const socket = ControlledWebSocket.instances[0];
+    expect(socket).toBeDefined();
+
+    const connectPromise = hub.connect();
+    socket!.simulateOpen();
+    await connectPromise;
+
+    handleInstrumentPartial(core, JSON.parse(JSON.stringify(INSTRUMENT_SNAPSHOT)));
+
+    const instrument = hub.instruments.get('btcusdt');
+    expect(instrument).toBeDefined();
+
+    const updates: number[] = [];
+    instrument!.on('update', () => {
+      updates.push(instrument!.trades.toArray().length);
+    });
+
+    const partialMessage: BitMexChannelMessage<'trade'> = {
+      table: 'trade',
+      action: 'partial',
+      data: [createTrade(0), createTrade(1), createTrade(2)],
+    };
+
+    socket!.simulateMessage(partialMessage);
+
+    const insertMessage: BitMexChannelMessage<'trade'> = {
+      table: 'trade',
+      action: 'insert',
+      data: [createTrade(3), createTrade(4)],
+    };
+
+    socket!.simulateMessage(insertMessage);
+
+    const snapshot = instrument!.trades.toArray();
+    expect(snapshot.length).toBeLessThanOrEqual(TRADE_BUFFER_DEFAULT);
+
+    const ids = snapshot.map((trade) => trade.id);
+    const uniqueIds = Array.from(new Set(ids));
+
+    expect(uniqueIds).toEqual(['trade-0', 'trade-1', 'trade-2', 'trade-3', 'trade-4']);
+    expect(updates.length).toBeGreaterThanOrEqual(2);
+
+    await hub.disconnect();
+  });
+});


### PR DESCRIPTION
## Summary
- implement the BitMEX trade channel to normalize partial/insert batches, log activity, and update each instrument's FIFO trade buffer
- extend the Instrument model with a configurable trade buffer, trade events, and supporting constants/types used during instrument creation and channel handling
- add unit and smoke tests that exercise buffer trimming, event emission, symbol mapping, and mock WebSocket message handling

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cae02fa5248320bf669333c3c54856