### PR TITLE
feat(bitmex): add order book L2 channel support

### DIFF
--- a/src/cores/bitmex/channelMessageHandlers/orderBookL2.ts
+++ b/src/cores/bitmex/channelMessageHandlers/orderBookL2.ts
@@ -1,20 +1,32 @@
+import { handleOrderBookMessage } from '../channels/orderBookL2.js';
+
 import type { BitMex } from '../index.js';
-import type { BitMexOrderBookL2 } from '../types.js';
+import type { BitMexChannelMessage } from '../types.js';
+
+type OrderBookMessage = BitMexChannelMessage<'orderBookL2'>;
+
+function forward(
+  core: BitMex,
+  action: OrderBookMessage['action'],
+  data: OrderBookMessage['data'],
+): void {
+  handleOrderBookMessage(core, { table: 'orderBookL2', action, data });
+}
 
 export const orderBookL2 = {
-  partial(_core: BitMex, _data: BitMexOrderBookL2[]) {
-    throw 'not implemented';
+  partial(core: BitMex, data: OrderBookMessage['data']) {
+    forward(core, 'partial', data);
   },
 
-  insert(_core: BitMex, _data: BitMexOrderBookL2[]) {
-    throw 'not implemented';
+  insert(core: BitMex, data: OrderBookMessage['data']) {
+    forward(core, 'insert', data);
   },
 
-  update(_core: BitMex, _data: BitMexOrderBookL2[]) {
-    throw 'not implemented';
+  update(core: BitMex, data: OrderBookMessage['data']) {
+    forward(core, 'update', data);
   },
 
-  delete(_core: BitMex, _data: BitMexOrderBookL2[]) {
-    throw 'not implemented';
+  delete(core: BitMex, data: OrderBookMessage['data']) {
+    forward(core, 'delete', data);
   },
 };

--- a/src/cores/bitmex/channels/orderBookL2.ts
+++ b/src/cores/bitmex/channels/orderBookL2.ts
@@ -1,0 +1,326 @@
+import { createLogger } from '../../../infra/logger.js';
+import { mapSymbolNativeToUni } from '../../../utils/symbolMapping.js';
+
+import type { Instrument } from '../../../domain/instrument.js';
+import type { BitmexOrderBookL2Raw } from '../../../types/bitmex.js';
+import type { L2Row } from '../../../types/orderbook.js';
+import type { BitMex } from '../index.js';
+import type { BitMexChannelMessage } from '../types.js';
+
+const log = createLogger('bitmex:orderbook');
+
+type OrderBookMessage = BitMexChannelMessage<'orderBookL2'>;
+type L2UpdateRow = Pick<L2Row, 'id'> & Partial<Omit<L2Row, 'id'>>;
+
+export function handleOrderBookMessage(core: BitMex, message: OrderBookMessage): void {
+  const { action, data } = message;
+
+  switch (action) {
+    case 'partial':
+      handleL2Partial(core, data);
+      break;
+    case 'insert':
+      handleL2Insert(core, data);
+      break;
+    case 'update':
+      handleL2Update(core, data);
+      break;
+    case 'delete':
+      handleL2Delete(core, data);
+      break;
+    default:
+      break;
+  }
+}
+
+export function handleL2Partial(core: BitMex, rows: BitmexOrderBookL2Raw[]): void {
+  if (!Array.isArray(rows) || rows.length === 0) {
+    return;
+  }
+
+  for (const [symbol, batch] of groupBySymbol(rows)) {
+    const instrument = resolveInstrument(core, symbol);
+
+    if (!instrument) {
+      log.debug('BitMEX orderBookL2 partial ignored: instrument not found for %s', symbol);
+      continue;
+    }
+
+    const { rows: snapshot, bids, asks } = normalizeSnapshot(batch);
+    const book = instrument.orderBook;
+
+    book.reset(snapshot);
+
+    book.emit('update', {
+      changed: { bids, asks },
+      bestBid: book.bestBid,
+      bestAsk: book.bestAsk,
+    });
+  }
+}
+
+export function handleL2Insert(core: BitMex, rows: BitmexOrderBookL2Raw[]): void {
+  if (!Array.isArray(rows) || rows.length === 0) {
+    return;
+  }
+
+  for (const [symbol, batch] of groupBySymbol(rows)) {
+    const instrument = resolveInstrument(core, symbol);
+
+    if (!instrument) {
+      log.debug('BitMEX orderBookL2 insert ignored: instrument not found for %s', symbol);
+      continue;
+    }
+
+    const { rows: normalized } = normalizeSnapshot(batch);
+
+    if (normalized.length === 0) {
+      continue;
+    }
+
+    const book = instrument.orderBook;
+    const wasOutOfSync = book.outOfSync;
+    const delta = book.applyInsert(normalized);
+
+    book.emit('update', delta);
+
+    if (!wasOutOfSync && book.outOfSync) {
+      log.warn('BitMEX orderBookL2 insert out-of-sync for %s, requesting resubscribe', symbol);
+      core.resubscribeOrderBook(symbol);
+    }
+  }
+}
+
+export function handleL2Update(core: BitMex, rows: BitmexOrderBookL2Raw[]): void {
+  if (!Array.isArray(rows) || rows.length === 0) {
+    return;
+  }
+
+  for (const [symbol, batch] of groupBySymbol(rows)) {
+    const instrument = resolveInstrument(core, symbol);
+
+    if (!instrument) {
+      log.debug('BitMEX orderBookL2 update ignored: instrument not found for %s', symbol);
+      continue;
+    }
+
+    const updates = normalizeUpdate(batch);
+
+    if (updates.length === 0) {
+      continue;
+    }
+
+    const book = instrument.orderBook;
+    const wasOutOfSync = book.outOfSync;
+    const delta = book.applyUpdate(updates);
+
+    book.emit('update', delta);
+
+    if (!wasOutOfSync && book.outOfSync) {
+      log.warn('BitMEX orderBookL2 update out-of-sync for %s, requesting resubscribe', symbol);
+      core.resubscribeOrderBook(symbol);
+    }
+  }
+}
+
+export function handleL2Delete(core: BitMex, rows: BitmexOrderBookL2Raw[]): void {
+  if (!Array.isArray(rows) || rows.length === 0) {
+    return;
+  }
+
+  for (const [symbol, batch] of groupBySymbol(rows)) {
+    const instrument = resolveInstrument(core, symbol);
+
+    if (!instrument) {
+      log.debug('BitMEX orderBookL2 delete ignored: instrument not found for %s', symbol);
+      continue;
+    }
+
+    const ids = normalizeIds(batch);
+
+    if (ids.length === 0) {
+      continue;
+    }
+
+    const book = instrument.orderBook;
+    const wasOutOfSync = book.outOfSync;
+    const delta = book.applyDelete(ids);
+
+    book.emit('update', delta);
+
+    if (!wasOutOfSync && book.outOfSync) {
+      log.warn('BitMEX orderBookL2 delete out-of-sync for %s, requesting resubscribe', symbol);
+      core.resubscribeOrderBook(symbol);
+    }
+  }
+}
+
+function groupBySymbol(rows: BitmexOrderBookL2Raw[]): Map<string, BitmexOrderBookL2Raw[]> {
+  const grouped = new Map<string, BitmexOrderBookL2Raw[]>();
+
+  for (const row of rows) {
+    const symbol = typeof row?.symbol === 'string' ? row.symbol.trim() : '';
+
+    if (!symbol) {
+      continue;
+    }
+
+    if (!grouped.has(symbol)) {
+      grouped.set(symbol, []);
+    }
+
+    grouped.get(symbol)!.push(row);
+  }
+
+  return grouped;
+}
+
+function resolveInstrument(core: BitMex, symbol: string): Instrument | undefined {
+  const normalized = typeof symbol === 'string' ? symbol.trim() : '';
+
+  if (!normalized) {
+    return undefined;
+  }
+
+  const direct =
+    core.getInstrumentByNative(normalized) ??
+    core.instruments.get(normalized) ??
+    core.instruments.get(normalized.toLowerCase()) ??
+    core.instruments.get(normalized.toUpperCase());
+
+  if (direct) {
+    return direct;
+  }
+
+  const unified = mapSymbolNativeToUni(normalized, { enabled: core.symbolMappingEnabled });
+
+  return (
+    core.instruments.get(unified) ??
+    core.instruments.get(unified.toLowerCase()) ??
+    core.instruments.get(unified.toUpperCase())
+  );
+}
+
+function normalizeSnapshot(rows: BitmexOrderBookL2Raw[]): {
+  rows: L2Row[];
+  bids: number;
+  asks: number;
+} {
+  const normalized: L2Row[] = [];
+  let bids = 0;
+  let asks = 0;
+
+  for (const row of rows) {
+    const normalizedRow = normalizeFullRow(row);
+
+    if (!normalizedRow) {
+      continue;
+    }
+
+    normalized.push(normalizedRow);
+    if (normalizedRow.side === 'buy') {
+      bids += 1;
+    } else {
+      asks += 1;
+    }
+  }
+
+  return { rows: normalized, bids, asks };
+}
+
+function normalizeFullRow(row: BitmexOrderBookL2Raw): L2Row | null {
+  if (!row || typeof row.id !== 'number') {
+    return null;
+  }
+
+  const price = toNumber(row.price);
+  const size = toNumber(row.size);
+
+  if (price === null || size === null) {
+    return null;
+  }
+
+  const side = normalizeSide(row.side);
+
+  if (!side) {
+    return null;
+  }
+
+  return {
+    id: row.id,
+    side,
+    price,
+    size,
+  };
+}
+
+function normalizeUpdate(rows: BitmexOrderBookL2Raw[]): L2UpdateRow[] {
+  const normalized: L2UpdateRow[] = [];
+
+  for (const row of rows) {
+    if (!row || typeof row.id !== 'number') {
+      continue;
+    }
+
+    const update: L2UpdateRow = { id: row.id };
+    let hasPayload = false;
+
+    const side = normalizeSide(row.side);
+    if (side) {
+      update.side = side;
+      hasPayload = true;
+    }
+
+    const price = toNumber(row.price);
+    if (price !== null) {
+      update.price = price;
+      hasPayload = true;
+    }
+
+    const size = toNumber(row.size);
+    if (size !== null) {
+      update.size = size;
+      hasPayload = true;
+    }
+
+    if (hasPayload) {
+      normalized.push(update);
+    }
+  }
+
+  return normalized;
+}
+
+function normalizeIds(rows: BitmexOrderBookL2Raw[]): number[] {
+  const ids: number[] = [];
+
+  for (const row of rows) {
+    if (typeof row?.id === 'number') {
+      ids.push(row.id);
+    }
+  }
+
+  return ids;
+}
+
+function normalizeSide(side: BitmexOrderBookL2Raw['side']): 'buy' | 'sell' | null {
+  if (side === 'Buy') {
+    return 'buy';
+  }
+
+  if (side === 'Sell') {
+    return 'sell';
+  }
+
+  return null;
+}
+
+function toNumber(value: unknown): number | null {
+  if (value === undefined || value === null) {
+    return null;
+  }
+
+  const num = Number(value);
+
+  return Number.isFinite(num) ? num : null;
+}

--- a/src/cores/bitmex/constants.ts
+++ b/src/cores/bitmex/constants.ts
@@ -17,6 +17,9 @@ export const BITMEX_PRIVATE_CHANNELS = [
 
 export const BITMEX_CHANNELS = [...BITMEX_PUBLIC_CHANNELS, ...BITMEX_PRIVATE_CHANNELS] as const;
 
+export const L2_CHANNEL = 'orderBookL2';
+export const L2_MAX_DEPTH_HINT = 0; // 0 = full order book
+
 export const BITMEX_WS_ENDPOINTS = {
   mainnet: 'wss://www.bitmex.com/realtime',
   testnet: 'wss://testnet.bitmex.com/realtime',

--- a/src/domain/orderBookL2.ts
+++ b/src/domain/orderBookL2.ts
@@ -1,0 +1,311 @@
+import { EventEmitter } from 'node:events';
+
+import { createLogger } from '../infra/logger.js';
+
+import type { L2BatchDelta, L2Best, L2Row } from '../types/orderbook.js';
+
+type L2UpdateRow = Pick<L2Row, 'id'> & Partial<Omit<L2Row, 'id'>>;
+
+type PriceLevel = {
+  totalSize: number;
+  orderIds: Set<number>;
+};
+
+export class OrderBookL2 extends EventEmitter {
+  public readonly log = createLogger('orderbook:l2');
+
+  public readonly rows = new Map<number, L2Row>();
+
+  public bestBid: L2Best | null = null;
+  public bestAsk: L2Best | null = null;
+  public outOfSync = false;
+
+  #levels: Record<'buy' | 'sell', Map<number, PriceLevel>> = {
+    buy: new Map(),
+    sell: new Map(),
+  };
+
+  // --- Events typing ---
+  public override on(event: 'update', listener: (delta: L2BatchDelta) => void): this;
+  public override on(event: string | symbol, listener: (...args: any[]) => void): this;
+  public override on(event: string | symbol, listener: (...args: any[]) => void): this {
+    return super.on(event, listener);
+  }
+
+  public override once(event: 'update', listener: (delta: L2BatchDelta) => void): this;
+  public override once(event: string | symbol, listener: (...args: any[]) => void): this;
+  public override once(event: string | symbol, listener: (...args: any[]) => void): this {
+    return super.once(event, listener);
+  }
+
+  public override off(event: 'update', listener: (delta: L2BatchDelta) => void): this;
+  public override off(event: string | symbol, listener: (...args: any[]) => void): this;
+  public override off(event: string | symbol, listener: (...args: any[]) => void): this {
+    return super.off(event, listener);
+  }
+
+  public override emit(event: 'update', delta: L2BatchDelta): boolean;
+  public override emit(event: string | symbol, ...args: any[]): boolean;
+  public override emit(event: string | symbol, ...args: any[]): boolean {
+    return super.emit(event, ...args);
+  }
+
+  reset(snapshot: L2Row[]): void {
+    this.rows.clear();
+    this.#levels.buy.clear();
+    this.#levels.sell.clear();
+    this.bestBid = null;
+    this.bestAsk = null;
+    this.outOfSync = false;
+
+    for (const row of snapshot) {
+      this.#insertRow(row);
+    }
+
+    this.#refreshBest('buy');
+    this.#refreshBest('sell');
+  }
+
+  applyInsert(rows: L2Row[]): L2BatchDelta {
+    let bids = 0;
+    let asks = 0;
+    const touched = new Set<'buy' | 'sell'>();
+
+    for (const row of rows) {
+      const inserted = this.#insertRow(row);
+
+      if (!inserted) {
+        continue;
+      }
+
+      touched.add(row.side);
+      if (row.side === 'buy') {
+        bids += 1;
+      } else {
+        asks += 1;
+      }
+    }
+
+    for (const side of touched) {
+      this.#refreshBest(side);
+    }
+
+    return this.#buildDelta(bids, asks);
+  }
+
+  applyUpdate(rows: L2UpdateRow[]): L2BatchDelta {
+    let bids = 0;
+    let asks = 0;
+    const touched = new Set<'buy' | 'sell'>();
+
+    for (const update of rows) {
+      const current = this.rows.get(update.id);
+
+      if (!current) {
+        this.outOfSync = true;
+        continue;
+      }
+
+      const { side } = current;
+      const nextPrice = update.price ?? current.price;
+      const nextSize = update.size ?? current.size;
+
+      if (update.side && update.side !== side) {
+        this.outOfSync = true;
+        continue;
+      }
+
+      touched.add(side);
+      if (side === 'buy') {
+        bids += 1;
+      } else {
+        asks += 1;
+      }
+
+      if (nextPrice !== current.price) {
+        this.#removeFromLevel(side, current.price, current.id, current.size);
+        current.price = nextPrice;
+        current.size = nextSize;
+        this.#addToLevel(current);
+        continue;
+      }
+
+      if (nextSize !== current.size) {
+        const deltaSize = nextSize - current.size;
+        current.size = nextSize;
+        this.#updateLevelSize(side, nextPrice, current.id, deltaSize);
+      }
+    }
+
+    for (const side of touched) {
+      this.#refreshBest(side);
+    }
+
+    return this.#buildDelta(bids, asks);
+  }
+
+  applyDelete(ids: number[]): L2BatchDelta {
+    let bids = 0;
+    let asks = 0;
+    const touched = new Set<'buy' | 'sell'>();
+
+    for (const id of ids) {
+      const current = this.rows.get(id);
+
+      if (!current) {
+        this.outOfSync = true;
+        continue;
+      }
+
+      touched.add(current.side);
+      if (current.side === 'buy') {
+        bids += 1;
+      } else {
+        asks += 1;
+      }
+
+      this.rows.delete(id);
+      this.#removeFromLevel(current.side, current.price, current.id, current.size);
+    }
+
+    for (const side of touched) {
+      this.#refreshBest(side);
+    }
+
+    return this.#buildDelta(bids, asks);
+  }
+
+  #insertRow(row: L2Row): boolean {
+    if (!row || typeof row.id !== 'number') {
+      return false;
+    }
+
+    if (this.rows.has(row.id)) {
+      this.outOfSync = true;
+      this.log.warn('duplicate L2 id', { id: row.id });
+      return false;
+    }
+
+    const normalized: L2Row = {
+      id: row.id,
+      side: row.side,
+      price: row.price,
+      size: row.size,
+    };
+
+    this.rows.set(normalized.id, normalized);
+    this.#addToLevel(normalized);
+
+    return true;
+  }
+
+  #addToLevel(row: L2Row): void {
+    const level = this.#ensureLevel(row.side, row.price);
+    if (!level.orderIds.has(row.id)) {
+      level.orderIds.add(row.id);
+      level.totalSize += row.size;
+      return;
+    }
+
+    const previous = this.rows.get(row.id);
+    if (previous) {
+      const delta = row.size - previous.size;
+      if (delta !== 0) {
+        level.totalSize = Math.max(0, level.totalSize + delta);
+      }
+    }
+  }
+
+  #removeFromLevel(side: 'buy' | 'sell', price: number, id: number, size: number): void {
+    const levels = this.#levels[side];
+    const level = levels.get(price);
+
+    if (!level) {
+      this.outOfSync = true;
+      return;
+    }
+
+    if (!level.orderIds.delete(id)) {
+      this.outOfSync = true;
+      return;
+    }
+
+    level.totalSize = Math.max(0, level.totalSize - size);
+
+    if (level.orderIds.size === 0) {
+      levels.delete(price);
+    }
+  }
+
+  #updateLevelSize(side: 'buy' | 'sell', price: number, id: number, deltaSize: number): void {
+    if (deltaSize === 0) {
+      return;
+    }
+
+    const level = this.#levels[side].get(price);
+
+    if (!level || !level.orderIds.has(id)) {
+      this.outOfSync = true;
+      return;
+    }
+
+    level.totalSize = Math.max(0, level.totalSize + deltaSize);
+  }
+
+  #refreshBest(side: 'buy' | 'sell'): void {
+    const levels = this.#levels[side];
+    let bestPrice: number | null = null;
+    let bestSize = 0;
+
+    for (const [price, level] of levels) {
+      if (level.orderIds.size === 0) {
+        levels.delete(price);
+        continue;
+      }
+
+      if (bestPrice === null) {
+        bestPrice = price;
+        bestSize = level.totalSize;
+        continue;
+      }
+
+      if (side === 'buy') {
+        if (price > bestPrice || (price === bestPrice && level.totalSize > bestSize)) {
+          bestPrice = price;
+          bestSize = level.totalSize;
+        }
+      } else if (price < bestPrice || (price === bestPrice && level.totalSize > bestSize)) {
+        bestPrice = price;
+        bestSize = level.totalSize;
+      }
+    }
+
+    if (side === 'buy') {
+      this.bestBid = bestPrice === null ? null : { price: bestPrice, size: bestSize };
+    } else {
+      this.bestAsk = bestPrice === null ? null : { price: bestPrice, size: bestSize };
+    }
+  }
+
+  #ensureLevel(side: 'buy' | 'sell', price: number): PriceLevel {
+    const levels = this.#levels[side];
+    let level = levels.get(price);
+
+    if (!level) {
+      level = { totalSize: 0, orderIds: new Set() };
+      levels.set(price, level);
+    }
+
+    return level;
+  }
+
+  #buildDelta(bids: number, asks: number): L2BatchDelta {
+    return {
+      changed: { bids, asks },
+      bestBid: this.bestBid,
+      bestAsk: this.bestAsk,
+    };
+  }
+}
+
+export type { L2BatchDelta, L2Best, L2Row };

--- a/src/types/bitmex.ts
+++ b/src/types/bitmex.ts
@@ -20,3 +20,13 @@ export type Trade = {
 };
 
 export type BitmexTrade = Trade;
+
+export type BitmexOrderBookL2Raw = {
+  symbol: string;
+  id: number;
+  side: 'Buy' | 'Sell';
+  size?: number;
+  price?: number;
+  timestamp?: string;
+  transactTime?: string;
+};

--- a/src/types/orderbook.ts
+++ b/src/types/orderbook.ts
@@ -1,0 +1,20 @@
+export type L2Row = {
+  id: number;
+  side: 'buy' | 'sell';
+  price: number;
+  size: number;
+};
+
+export type L2Best = {
+  price: number;
+  size: number;
+};
+
+export type L2BatchDelta = {
+  changed: {
+    bids: number;
+    asks: number;
+  };
+  bestBid?: L2Best | null;
+  bestAsk?: L2Best | null;
+};

--- a/tests/bitmex/orderbook.unit.test.ts
+++ b/tests/bitmex/orderbook.unit.test.ts
@@ -1,0 +1,103 @@
+import { OrderBookL2 } from '../../src/domain/orderBookL2.js';
+
+import type { L2Row } from '../../src/types/orderbook.js';
+
+describe('OrderBookL2 (unit)', () => {
+  test('reset builds price levels and aggregates best bid/ask', () => {
+    const book = new OrderBookL2();
+    const snapshot: L2Row[] = [
+      { id: 1, side: 'buy', price: 100, size: 2 },
+      { id: 2, side: 'buy', price: 101, size: 4 },
+      { id: 3, side: 'buy', price: 101, size: 3 },
+      { id: 4, side: 'sell', price: 103, size: 5 },
+      { id: 5, side: 'sell', price: 102, size: 1 },
+    ];
+
+    book.reset(snapshot);
+
+    expect(book.rows.size).toBe(5);
+    expect(book.bestBid).toEqual({ price: 101, size: 7 });
+    expect(book.bestAsk).toEqual({ price: 102, size: 1 });
+    expect(book.outOfSync).toBe(false);
+  });
+
+  test('applyInsert adds rows and recomputes best quotes', () => {
+    const book = new OrderBookL2();
+    book.reset([
+      { id: 1, side: 'buy', price: 100, size: 2 },
+      { id: 2, side: 'sell', price: 105, size: 3 },
+    ]);
+
+    const delta = book.applyInsert([
+      { id: 3, side: 'buy', price: 101, size: 1 },
+      { id: 4, side: 'sell', price: 104, size: 2 },
+      { id: 5, side: 'sell', price: 102, size: 4 },
+    ]);
+
+    expect(book.rows.size).toBe(5);
+    expect(delta.changed).toEqual({ bids: 1, asks: 2 });
+    expect(book.bestBid).toEqual({ price: 101, size: 1 });
+    expect(book.bestAsk).toEqual({ price: 102, size: 4 });
+    expect(book.outOfSync).toBe(false);
+  });
+
+  test('applyUpdate moves orders across price levels and updates best quotes', () => {
+    const book = new OrderBookL2();
+    book.reset([
+      { id: 1, side: 'buy', price: 100, size: 3 },
+      { id: 2, side: 'buy', price: 101, size: 1 },
+      { id: 3, side: 'sell', price: 103, size: 2 },
+      { id: 4, side: 'sell', price: 104, size: 5 },
+    ]);
+
+    const delta = book.applyUpdate([
+      { id: 1, price: 102 },
+      { id: 3, size: 1 },
+    ]);
+
+    expect(delta.changed).toEqual({ bids: 1, asks: 1 });
+    expect(book.rows.get(1)).toEqual({ id: 1, side: 'buy', price: 102, size: 3 });
+    expect(book.rows.get(3)).toEqual({ id: 3, side: 'sell', price: 103, size: 1 });
+    expect(book.bestBid).toEqual({ price: 102, size: 3 });
+    expect(book.bestAsk).toEqual({ price: 103, size: 1 });
+    expect(book.outOfSync).toBe(false);
+  });
+
+  test('applyDelete removes rows and recomputes best quotes', () => {
+    const book = new OrderBookL2();
+    book.reset([
+      { id: 1, side: 'buy', price: 100, size: 2 },
+      { id: 2, side: 'buy', price: 101, size: 3 },
+      { id: 3, side: 'sell', price: 105, size: 3 },
+      { id: 4, side: 'sell', price: 102, size: 1 },
+    ]);
+
+    const delta = book.applyDelete([2, 4]);
+
+    expect(delta.changed).toEqual({ bids: 1, asks: 1 });
+    expect(book.rows.has(2)).toBe(false);
+    expect(book.rows.has(4)).toBe(false);
+    expect(book.bestBid).toEqual({ price: 100, size: 2 });
+    expect(book.bestAsk).toEqual({ price: 105, size: 3 });
+    expect(book.outOfSync).toBe(false);
+  });
+
+  test('marks outOfSync on inconsistent operations and reset clears the flag', () => {
+    const book = new OrderBookL2();
+    book.reset([{ id: 10, side: 'buy', price: 99, size: 2 }]);
+
+    expect(book.outOfSync).toBe(false);
+
+    const insertDelta = book.applyInsert([{ id: 10, side: 'buy', price: 100, size: 1 }]);
+    expect(insertDelta.changed).toEqual({ bids: 0, asks: 0 });
+    expect(book.outOfSync).toBe(true);
+
+    const updateDelta = book.applyUpdate([{ id: 999, size: 5 }]);
+    expect(updateDelta.changed).toEqual({ bids: 0, asks: 0 });
+    expect(book.outOfSync).toBe(true);
+
+    book.reset([{ id: 11, side: 'sell', price: 105, size: 4 }]);
+    expect(book.outOfSync).toBe(false);
+    expect(book.bestAsk).toEqual({ price: 105, size: 4 });
+  });
+});

--- a/tests/ws/orderbook.smoke.test.ts
+++ b/tests/ws/orderbook.smoke.test.ts
@@ -1,0 +1,201 @@
+import { ExchangeHub } from '../../src/ExchangeHub.js';
+import { handleInstrumentPartial } from '../../src/cores/bitmex/channels/instrument.js';
+
+import type { BitMex } from '../../src/cores/bitmex/index.js';
+import type { BitMexChannelMessage } from '../../src/cores/bitmex/types.js';
+import type { BitMexInstrument } from '../../src/cores/bitmex/types.js';
+import type { BitmexOrderBookL2Raw } from '../../src/types/bitmex.js';
+import type { L2BatchDelta } from '../../src/types/orderbook.js';
+
+class ControlledWebSocket {
+  static instances: ControlledWebSocket[] = [];
+
+  public readonly url: string;
+  public onmessage: ((event: { data: unknown }) => void) | null = null;
+  public onopen: (() => void) | null = null;
+  public onerror: ((err: unknown) => void) | null = null;
+  public onclose: ((event?: { code?: number; reason?: string }) => void) | null = null;
+
+  #listeners = new Map<string, Set<(...args: unknown[]) => void>>();
+
+  constructor(url: string) {
+    this.url = url;
+    ControlledWebSocket.instances.push(this);
+  }
+
+  addEventListener(event: string, listener: (...args: unknown[]) => void): void {
+    if (!this.#listeners.has(event)) {
+      this.#listeners.set(event, new Set());
+    }
+
+    this.#listeners.get(event)!.add(listener);
+  }
+
+  removeEventListener(event: string, listener: (...args: unknown[]) => void): void {
+    this.#listeners.get(event)?.delete(listener);
+  }
+
+  send(_data: string): void {}
+
+  close(): void {
+    this.#emit('close', { code: 1000, reason: 'client-request' });
+  }
+
+  simulateOpen(): void {
+    this.#emit('open');
+  }
+
+  simulateMessage(message: BitMexChannelMessage<any>): void {
+    const payload = JSON.stringify(message);
+    this.#emit('message', { data: payload });
+  }
+
+  #emit(event: string, ...args: unknown[]): void {
+    const handler = (this as any)[`on${event}`];
+
+    if (typeof handler === 'function') {
+      handler(...args);
+    }
+
+    for (const listener of this.#listeners.get(event) ?? []) {
+      listener(...args);
+    }
+  }
+}
+
+const ORIGINAL_WEBSOCKET = (globalThis as any).WebSocket;
+
+beforeAll(() => {
+  (globalThis as any).WebSocket = ControlledWebSocket;
+});
+
+afterAll(() => {
+  (globalThis as any).WebSocket = ORIGINAL_WEBSOCKET;
+});
+
+afterEach(() => {
+  ControlledWebSocket.instances = [];
+});
+
+const INSTRUMENT_SNAPSHOT: BitMexInstrument[] = [
+  {
+    symbol: 'XBTUSD',
+    state: 'Open',
+    typ: 'FFWCSX',
+    quoteCurrency: 'USD',
+    underlying: 'XBT',
+    lotSize: 100,
+    tickSize: 0.5,
+    lastPrice: 50_000,
+    timestamp: '2024-01-01T00:00:00.000Z',
+  },
+];
+
+function buildMessage(
+  action: BitMexChannelMessage<'orderBookL2'>['action'],
+  data: BitmexOrderBookL2Raw[],
+): BitMexChannelMessage<'orderBookL2'> {
+  return {
+    table: 'orderBookL2',
+    action,
+    data,
+  };
+}
+
+describe('BitMEX orderBookL2 channel smoke test', () => {
+  test('partial→insert→update→delete emit exactly one update per batch and trigger resubscribe on desync', async () => {
+    const hub = new ExchangeHub('BitMex', { isTest: true });
+    const core = hub.Core as BitMex;
+    const socket = ControlledWebSocket.instances[0];
+
+    expect(socket).toBeDefined();
+
+    const connectPromise = hub.connect();
+    socket!.simulateOpen();
+    await connectPromise;
+
+    handleInstrumentPartial(core, JSON.parse(JSON.stringify(INSTRUMENT_SNAPSHOT)));
+
+    const instrument = hub.instruments.get('btcusdt');
+    expect(instrument).toBeDefined();
+
+    const book = instrument!.orderBook;
+    const events: L2BatchDelta[] = [];
+    book.on('update', (delta) => events.push(delta));
+
+    const partialData: BitmexOrderBookL2Raw[] = [
+      { symbol: 'XBTUSD', id: 1_000_000_001, side: 'Buy', price: 99, size: 2 },
+      { symbol: 'XBTUSD', id: 1_000_000_002, side: 'Buy', price: 99, size: 3 },
+      { symbol: 'XBTUSD', id: 2_000_000_001, side: 'Sell', price: 100, size: 4 },
+      { symbol: 'XBTUSD', id: 2_000_000_002, side: 'Sell', price: 101, size: 1 },
+    ];
+
+    socket!.simulateMessage(buildMessage('partial', partialData));
+
+    expect(events).toHaveLength(1);
+    expect(events[0].changed).toEqual({ bids: 2, asks: 2 });
+    expect(book.bestBid).toEqual({ price: 99, size: 5 });
+    expect(book.bestAsk).toEqual({ price: 100, size: 4 });
+
+    events.length = 0;
+
+    const insertData: BitmexOrderBookL2Raw[] = [
+      { symbol: 'XBTUSD', id: 1_000_000_003, side: 'Buy', price: 100, size: 1 },
+      { symbol: 'XBTUSD', id: 2_000_000_003, side: 'Sell', price: 99.5, size: 2 },
+    ];
+
+    socket!.simulateMessage(buildMessage('insert', insertData));
+
+    expect(events).toHaveLength(1);
+    expect(events[0].changed).toEqual({ bids: 1, asks: 1 });
+    expect(book.bestBid).toEqual({ price: 100, size: 1 });
+    expect(book.bestAsk).toEqual({ price: 99.5, size: 2 });
+
+    events.length = 0;
+
+    const updateData: BitmexOrderBookL2Raw[] = [
+      { symbol: 'XBTUSD', id: 1_000_000_002, side: 'Buy', price: 100.2 },
+      { symbol: 'XBTUSD', id: 2_000_000_001, side: 'Sell', size: 2 },
+    ];
+
+    socket!.simulateMessage(buildMessage('update', updateData));
+
+    expect(events).toHaveLength(1);
+    expect(events[0].changed).toEqual({ bids: 1, asks: 1 });
+    expect(book.bestBid).toEqual({ price: 100.2, size: 3 });
+    expect(book.bestAsk).toEqual({ price: 99.5, size: 2 });
+
+    events.length = 0;
+
+    const deleteData: BitmexOrderBookL2Raw[] = [
+      { symbol: 'XBTUSD', id: 2_000_000_003, side: 'Sell' },
+      { symbol: 'XBTUSD', id: 1_000_000_003, side: 'Buy' },
+    ];
+
+    socket!.simulateMessage(buildMessage('delete', deleteData));
+
+    expect(events).toHaveLength(1);
+    expect(events[0].changed).toEqual({ bids: 1, asks: 1 });
+    expect(book.bestBid).toEqual({ price: 100.2, size: 3 });
+    expect(book.bestAsk).toEqual({ price: 100, size: 2 });
+
+    events.length = 0;
+
+    const resubscribeSpy = jest.spyOn(core, 'resubscribeOrderBook');
+
+    const badUpdate: BitmexOrderBookL2Raw[] = [
+      { symbol: 'XBTUSD', id: 9_999_999_999, side: 'Buy', size: 5 },
+    ];
+
+    socket!.simulateMessage(buildMessage('update', badUpdate));
+
+    expect(events).toHaveLength(1);
+    expect(book.outOfSync).toBe(true);
+    expect(resubscribeSpy).toHaveBeenCalledTimes(1);
+    expect(resubscribeSpy).toHaveBeenCalledWith('XBTUSD');
+
+    resubscribeSpy.mockRestore();
+
+    await hub.disconnect();
+  });
+});

--- a/tests/ws/trade.smoke.test.ts
+++ b/tests/ws/trade.smoke.test.ts
@@ -48,7 +48,6 @@ class ControlledWebSocket {
 
   simulateMessage(message: BitMexChannelMessage<any>): void {
     const payload = JSON.stringify(message);
-    this.onmessage?.({ data: payload });
     this.#emit('message', { data: payload });
   }
 


### PR DESCRIPTION
## Summary
- add an OrderBookL2 domain model with best bid/ask tracking, sequence safety and batch deltas
- integrate the order book into BitMEX instruments and wire up the orderBookL2 channel with partial/insert/update/delete handling
- ensure websocket smoke tests use single message delivery and keep trade buffers chronologically sorted

## Testing
- npm run lint
- npm run format:check
- npm run type-check
- npm run build
- npm test -- tests/bitmex/trade.test.ts
- npm test -- tests/ws/orderbook.smoke.test.ts
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cbbddf49a48320ace292759669632f