### PR TITLE
feat: add shared private channel primitives

### DIFF
--- a/src/core/private/resubscribe-flow.ts
+++ b/src/core/private/resubscribe-flow.ts
@@ -1,0 +1,12 @@
+export interface PrivateResubscribeFlow {
+  /** вызывается транспортом после события 'authed' */
+  onAuthedResubscribe(): Promise<void>;
+}
+
+export class DefaultPrivateResubscribeFlow implements PrivateResubscribeFlow {
+  constructor(private readonly doResubscribe: () => Promise<void>) {}
+
+  async onAuthedResubscribe(): Promise<void> {
+    await this.doResubscribe();
+  }
+}

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,0 +1,24 @@
+export type Symbol = string;
+export type AccountId = string;
+export type OrderID = string;
+export type ClOrdID = string;
+export type TimestampISO = string;
+export type Liquidity = 'maker' | 'taker';
+
+export interface DomainUpdate<T> {
+  prev: T;
+  next: T;
+  changed: (keyof T)[];
+}
+
+export interface BaseEntity<TSnapshot> {
+  getSnapshot(): TSnapshot;
+  on(
+    event: 'update',
+    handler: (next: TSnapshot, diff: DomainUpdate<TSnapshot>, reason?: string) => void,
+  ): this;
+  off(
+    event: 'update',
+    handler: (next: TSnapshot, diff: DomainUpdate<TSnapshot>, reason?: string) => void,
+  ): this;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import { createLogger } from './infra/logger.js';
 const log = createLogger('exchange-hub');
 log.info('ExchangeHub initialized');
 
-export { createLogger, getLevel, setLevel } from './infra/logger.js';
+export { createLogger, getLevel, setLevel, LOG_TAGS } from './infra/logger.js';
 export type { LogLevel, Logger } from './infra/logger.js';
 export {
   BaseError,
@@ -35,3 +35,20 @@ export {
   getAuthExpiresSkewSec,
   DEFAULT_AUTH_EXPIRES_SKEW_SEC,
 } from './config/bitmex.js';
+export type {
+  Symbol,
+  AccountId,
+  OrderID,
+  ClOrdID,
+  TimestampISO,
+  Liquidity,
+  DomainUpdate,
+  BaseEntity,
+} from './core/types.js';
+export { diffKeys } from './infra/diff.js';
+export { dedupeByKey } from './infra/dedupe.js';
+export { toIso, parseIsoTs, isNewerByTimestamp, normalizeWsTs } from './infra/time.js';
+export type { PrivateResubscribeFlow } from './core/private/resubscribe-flow.js';
+export { DefaultPrivateResubscribeFlow } from './core/private/resubscribe-flow.js';
+export { METRICS as PRIVATE_METRICS } from './infra/metrics-private.js';
+export type { PrivateLabels } from './infra/metrics-private.js';

--- a/src/infra/dedupe.ts
+++ b/src/infra/dedupe.ts
@@ -1,0 +1,15 @@
+export function dedupeByKey<T, K>(items: readonly T[], keyFn: (item: T) => K): T[] {
+  const seen = new Set<K>();
+  const result: T[] = [];
+
+  for (const item of items) {
+    const key = keyFn(item);
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    result.push(item);
+  }
+
+  return result;
+}

--- a/src/infra/diff.ts
+++ b/src/infra/diff.ts
@@ -1,0 +1,22 @@
+export function diffKeys<T extends Record<string, unknown>>(prev: T, next: T): (keyof T)[] {
+  const keys = new Set<keyof T>();
+  for (const key of Object.keys(prev) as (keyof T)[]) {
+    keys.add(key);
+  }
+  for (const key of Object.keys(next) as (keyof T)[]) {
+    keys.add(key);
+  }
+
+  const changed: (keyof T)[] = [];
+  for (const key of keys) {
+    const prevValue = prev[key];
+    const nextValue = next[key];
+    const prevSerialized = JSON.stringify(prevValue);
+    const nextSerialized = JSON.stringify(nextValue);
+    if (prevSerialized !== nextSerialized) {
+      changed.push(key);
+    }
+  }
+
+  return changed;
+}

--- a/src/infra/logger.ts
+++ b/src/infra/logger.ts
@@ -1,5 +1,16 @@
 import { format, inspect } from 'node:util';
 
+/** ВАЖНО: запрещено логировать секреты, ID ключей и подписи. */
+
+export const LOG_TAGS = {
+  ws: 'ws',
+  private: 'private',
+  wallet: 'wallet',
+  position: 'position',
+  order: 'order',
+  reconnect: 'reconnect',
+} as const;
+
 export type LogLevel = 'trace' | 'debug' | 'info' | 'warn' | 'error';
 
 const LEVELS: readonly LogLevel[] = ['trace', 'debug', 'info', 'warn', 'error'];

--- a/src/infra/metrics-private.ts
+++ b/src/infra/metrics-private.ts
@@ -1,0 +1,14 @@
+/* Согласованные имена метрик/лейблы для приватных каналов */
+export const METRICS = {
+  walletUpdateCount: 'wallet_update_count',
+  positionUpdateCount: 'position_update_count',
+  orderUpdateCount: 'order_update_count',
+  snapshotAgeSec: 'wallet_snapshot_age_sec',
+  privateLatencyMs: 'private_latency_ms',
+} as const;
+
+export type PrivateLabels = {
+  env: 'testnet' | 'mainnet';
+  table: 'wallet' | 'position' | 'order';
+  symbol?: string;
+};

--- a/src/infra/time.ts
+++ b/src/infra/time.ts
@@ -1,0 +1,48 @@
+import { TimestampISO } from '../core/types.js';
+
+export function toIso(input: number | Date): TimestampISO {
+  const date = typeof input === 'number' ? new Date(input) : new Date(input);
+  return date.toISOString();
+}
+
+export function parseIsoTs(value: string): number {
+  return Date.parse(value);
+}
+
+export function isNewerByTimestamp(prevIso?: string, nextIso?: string): boolean {
+  if (!nextIso) {
+    return false;
+  }
+  if (!prevIso) {
+    return true;
+  }
+  return parseIsoTs(nextIso) >= parseIsoTs(prevIso);
+}
+
+export function normalizeWsTs(ts?: string | number): TimestampISO | undefined {
+  if (ts === undefined || ts === null) {
+    return undefined;
+  }
+
+  if (typeof ts === 'number') {
+    const date = new Date(ts);
+    return Number.isNaN(date.getTime()) ? undefined : date.toISOString();
+  }
+
+  const trimmed = ts.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+
+  if (/^\d+$/.test(trimmed)) {
+    const numeric = Number(trimmed);
+    if (Number.isFinite(numeric)) {
+      const numericDate = new Date(numeric);
+      return Number.isNaN(numericDate.getTime()) ? undefined : numericDate.toISOString();
+    }
+    return undefined;
+  }
+
+  const parsed = new Date(trimmed);
+  return Number.isNaN(parsed.getTime()) ? undefined : parsed.toISOString();
+}

--- a/tests/unit/core/private/resubscribe-flow.test.ts
+++ b/tests/unit/core/private/resubscribe-flow.test.ts
@@ -1,0 +1,25 @@
+import {
+  DefaultPrivateResubscribeFlow,
+} from '../../../../src/core/private/resubscribe-flow.js';
+
+describe('DefaultPrivateResubscribeFlow', () => {
+  test('DefaultPrivateResubscribeFlow вызывает doResubscribe() ровно один раз на вызов onAuthedResubscribe()', async () => {
+    const doResubscribe = jest.fn(async () => {});
+    const flow = new DefaultPrivateResubscribeFlow(doResubscribe);
+
+    await flow.onAuthedResubscribe();
+    expect(doResubscribe).toHaveBeenCalledTimes(1);
+
+    await flow.onAuthedResubscribe();
+    expect(doResubscribe).toHaveBeenCalledTimes(2);
+  });
+
+  test('Ошибки doResubscribe пробрасываются вызывающему коду', async () => {
+    const error = new Error('resubscribe failed');
+    const flow = new DefaultPrivateResubscribeFlow(async () => {
+      throw error;
+    });
+
+    await expect(flow.onAuthedResubscribe()).rejects.toThrow(error);
+  });
+});

--- a/tests/unit/infra/dedupe.test.ts
+++ b/tests/unit/infra/dedupe.test.ts
@@ -1,0 +1,24 @@
+import { dedupeByKey } from '../../../src/infra/dedupe.js';
+
+describe('dedupeByKey', () => {
+  test('Дедуп по ключу возвращает первый экземпляр', () => {
+    const input = [
+      { id: 'a', value: 1 },
+      { id: 'b', value: 2 },
+      { id: 'a', value: 3 },
+      { id: 'c', value: 4 },
+      { id: 'b', value: 5 },
+    ];
+
+    const result = dedupeByKey(input, (item) => item.id);
+
+    expect(result).toHaveLength(3);
+    expect(result[0]).toBe(input[0]);
+    expect(result[1]).toBe(input[1]);
+    expect(result[2]).toBe(input[3]);
+  });
+
+  test('Пустой массив → пустой результат', () => {
+    expect(dedupeByKey([], () => 'noop')).toEqual([]);
+  });
+});

--- a/tests/unit/infra/diff.test.ts
+++ b/tests/unit/infra/diff.test.ts
@@ -1,0 +1,21 @@
+import { diffKeys } from '../../../src/infra/diff.js';
+
+describe('diffKeys', () => {
+  test('Изменение простых полей попадает в changed', () => {
+    const prev = { balance: 100, status: 'ok', currency: 'USD' };
+    const next = { balance: 150, status: 'stale', currency: 'USD' };
+
+    const changed = diffKeys(prev, next);
+
+    expect(changed.sort()).toEqual(['balance', 'status']);
+  });
+
+  test('Глубокие объекты сравниваются по JSON.stringify (ожидаемое поведение зафиксировать)', () => {
+    const prev = { meta: { a: 1, b: 2 } };
+    const next = { meta: { b: 2, a: 1 } };
+
+    const changed = diffKeys(prev, next);
+
+    expect(changed).toEqual(['meta']);
+  });
+});

--- a/tests/unit/infra/time.test.ts
+++ b/tests/unit/infra/time.test.ts
@@ -1,0 +1,47 @@
+import {
+  toIso,
+  parseIsoTs,
+  isNewerByTimestamp,
+  normalizeWsTs,
+} from '../../../src/infra/time.js';
+
+describe('time utils', () => {
+  test('toIso/parseIsoTs обратимы в пределах миллисекунд', () => {
+    const nowMs = Date.now();
+    const isoFromNumber = toIso(nowMs);
+    const roundtripMs = parseIsoTs(isoFromNumber);
+
+    expect(Math.abs(roundtripMs - nowMs)).toBeLessThanOrEqual(1);
+
+    const date = new Date(nowMs);
+    const isoFromDate = toIso(date);
+    const roundtripDate = parseIsoTs(isoFromDate);
+
+    expect(roundtripDate).toBe(date.getTime());
+  });
+
+  test('isNewerByTimestamp корректно сравнивает ISO-строки', () => {
+    const base = '2024-05-05T08:00:00.000Z';
+    const older = '2024-05-05T07:59:59.999Z';
+    const newer = '2024-05-05T08:00:00.001Z';
+
+    expect(isNewerByTimestamp(undefined, base)).toBe(true);
+    expect(isNewerByTimestamp(base, undefined)).toBe(false);
+    expect(isNewerByTimestamp(base, newer)).toBe(true);
+    expect(isNewerByTimestamp(base, older)).toBe(false);
+    expect(isNewerByTimestamp(base, base)).toBe(true);
+  });
+
+  test('normalizeWsTs поддерживает number|ISO', () => {
+    const msValue = 1_715_000_000_000;
+    const isoValue = '2024-05-05T08:00:00Z';
+    const numericAsString = `${msValue}`;
+
+    expect(normalizeWsTs(msValue)).toBe(new Date(msValue).toISOString());
+    expect(normalizeWsTs(isoValue)).toBe(new Date(isoValue).toISOString());
+    expect(normalizeWsTs(numericAsString)).toBe(new Date(msValue).toISOString());
+    expect(normalizeWsTs(undefined)).toBeUndefined();
+    expect(normalizeWsTs(null as unknown as undefined)).toBeUndefined();
+    expect(normalizeWsTs('invalid')).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- introduce shared domain types plus BaseEntity/DomainUpdate update contract for private channels
- add diff, dedupe, and timestamp utilities alongside default private resubscribe flow and metrics labels
- document the update contract and cover new helpers with unit tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd10f2a3988320b6820ad20fbdf0f6