### PR TITLE
Implement BitMEX wallet stream cache and tests

### DIFF
--- a/src/core/bitmex/channelMessageHandlers/wallet.ts
+++ b/src/core/bitmex/channelMessageHandlers/wallet.ts
@@ -1,20 +1,27 @@
+import {
+  handleWalletDelete,
+  handleWalletInsert,
+  handleWalletPartial,
+  handleWalletUpdate,
+} from '../channels/wallet.js';
+
 import type { BitMex } from '../index.js';
 import type { BitMexWallet } from '../types.js';
 
 export const wallet = {
-  partial(_core: BitMex, _data: BitMexWallet[]) {
-    throw 'not implemented';
+  partial(core: BitMex, data: BitMexWallet[]) {
+    handleWalletPartial(core, data);
   },
 
-  insert(_core: BitMex, _data: BitMexWallet[]) {
-    throw 'not implemented';
+  insert(core: BitMex, data: BitMexWallet[]) {
+    handleWalletInsert(core, data);
   },
 
-  update(_core: BitMex, _data: BitMexWallet[]) {
-    throw 'not implemented';
+  update(core: BitMex, data: BitMexWallet[]) {
+    handleWalletUpdate(core, data);
   },
 
-  delete(_core: BitMex, _data: BitMexWallet[]) {
-    throw 'not implemented';
+  delete(core: BitMex, data: BitMexWallet[]) {
+    handleWalletDelete(core, data);
   },
 };

--- a/src/core/bitmex/channels/wallet.ts
+++ b/src/core/bitmex/channels/wallet.ts
@@ -1,0 +1,356 @@
+import { createLogger, LOG_TAGS } from '../../../infra/logger.js';
+import { incrementCounter, observeHistogram } from '../../../infra/metrics.js';
+import { METRICS } from '../../../infra/metrics-private.js';
+import { normalizeWsTs, parseIsoTs } from '../../../infra/time.js';
+
+import { Wallet } from '../../../domain/wallet.js';
+
+import type { WalletBalanceInput } from '../../../domain/wallet.js';
+import type { PrivateLabels } from '../../../infra/metrics-private.js';
+import type { BitMex } from '../index.js';
+import type { BitMexWallet } from '../types.js';
+
+const log = createLogger('bitmex:wallet');
+const BASE_TAGS = [LOG_TAGS.ws, LOG_TAGS.private, LOG_TAGS.wallet] as const;
+
+export function handleWalletPartial(core: BitMex, rows: BitMexWallet[]): void {
+  processWalletRows(core, rows, {
+    reset: true,
+    action: 'partial',
+    resolveReason: ({ existed }) => (existed ? 'ws:resync' : 'ws:partial'),
+  });
+}
+
+export function handleWalletInsert(core: BitMex, rows: BitMexWallet[]): void {
+  processWalletRows(core, rows, {
+    reset: false,
+    action: 'insert',
+    resolveReason: () => 'ws:insert',
+  });
+}
+
+export function handleWalletUpdate(core: BitMex, rows: BitMexWallet[]): void {
+  processWalletRows(core, rows, {
+    reset: false,
+    action: 'update',
+    resolveReason: () => 'ws:update',
+  });
+}
+
+export function handleWalletDelete(core: BitMex, rows: BitMexWallet[]): void {
+  const normalized = normalizeWalletRows(rows);
+  if (normalized.length === 0) {
+    return;
+  }
+
+  const grouped = new Map<string, Set<string>>();
+
+  for (const row of normalized) {
+    let currencies = grouped.get(row.accountId);
+    if (!currencies) {
+      currencies = new Set();
+      grouped.set(row.accountId, currencies);
+    }
+
+    currencies.add(row.currencyDisplay);
+  }
+
+  if (grouped.size === 0) {
+    return;
+  }
+
+  for (const [accountId, currencies] of grouped) {
+    const wallet = core.shell.getWallet(accountId);
+    if (!wallet) {
+      continue;
+    }
+
+    const diff = wallet.removeCurrencies(Array.from(currencies), 'ws:delete');
+
+    if (!diff) {
+      continue;
+    }
+
+    recordMetrics(core, diff.next.updatedAt);
+    logWalletUpdate({
+      accountId,
+      existed: true,
+      action: 'delete',
+      reason: 'ws:delete',
+      changed: diff.changed,
+      updatedAt: diff.next.updatedAt,
+    });
+  }
+}
+
+type ProcessOptions = {
+  reset: boolean;
+  action: 'partial' | 'insert' | 'update';
+  resolveReason: (context: { existed: boolean }) => string;
+};
+
+type NormalizedWalletRow = {
+  accountId: string;
+  currencyKey: string;
+  currencyDisplay: string;
+  update: WalletBalanceInput;
+  timestampMs?: number;
+};
+
+type WalletBalanceUpdate = Omit<WalletBalanceInput, 'currency'>;
+
+function processWalletRows(core: BitMex, rows: BitMexWallet[], options: ProcessOptions): void {
+  const normalized = normalizeWalletRows(rows);
+
+  if (normalized.length === 0 && !options.reset) {
+    return;
+  }
+
+  const grouped = groupByAccount(normalized);
+
+  if (grouped.size === 0 && !options.reset) {
+    return;
+  }
+
+  for (const [accountId, updates] of grouped) {
+    const existed = Boolean(core.shell.getWallet(accountId));
+    const wallet = ensureWallet(core, accountId);
+    const reason = options.resolveReason({ existed });
+    const diff = wallet.apply(updates, { reset: options.reset, reason });
+
+    if (!diff) {
+      continue;
+    }
+
+    recordMetrics(core, diff.next.updatedAt);
+    logWalletUpdate({
+      accountId,
+      existed,
+      action: options.action,
+      reason,
+      changed: diff.changed,
+      updatedAt: diff.next.updatedAt,
+    });
+  }
+}
+
+function ensureWallet(core: BitMex, accountId: string): Wallet {
+  const existing = core.shell.getWallet(accountId);
+  if (existing) {
+    return existing;
+  }
+
+  return core.shell.ensureWallet(accountId);
+}
+
+function normalizeWalletRows(rows: BitMexWallet[]): NormalizedWalletRow[] {
+  const result: NormalizedWalletRow[] = [];
+
+  for (const row of rows ?? []) {
+    const normalized = normalizeWalletRow(row);
+    if (normalized) {
+      result.push(normalized);
+    }
+  }
+
+  return result;
+}
+
+function normalizeWalletRow(row: BitMexWallet): NormalizedWalletRow | null {
+  const accountId = normalizeAccountId(row.account);
+  const currency = normalizeCurrency(row.currency);
+
+  if (!accountId || !currency) {
+    return null;
+  }
+
+  const update: WalletBalanceInput = {
+    currency: currency.display,
+  };
+
+  assignNumberLike(update, 'amount', row.amount);
+  assignNumberLike(update, 'pendingCredit', row.pendingCredit);
+  assignNumberLike(update, 'pendingDebit', row.pendingDebit);
+  assignNumberLike(update, 'confirmedDebit', row.confirmedDebit);
+  assignNumberLike(update, 'transferIn', row.transferIn);
+  assignNumberLike(update, 'transferOut', row.transferOut);
+  assignNumberLike(update, 'deposited', row.deposited);
+  assignNumberLike(update, 'withdrawn', row.withdrawn);
+
+  const timestamp = normalizeWsTs(row.timestamp);
+  const timestampMs = timestamp ? parseIsoTs(timestamp) : undefined;
+
+  if (timestamp) {
+    update.timestamp = timestamp;
+  }
+
+  return {
+    accountId,
+    currencyKey: currency.key,
+    currencyDisplay: currency.display,
+    update,
+    timestampMs,
+  };
+}
+
+function normalizeAccountId(value: unknown): string | undefined {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return Math.trunc(value).toString();
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed || undefined;
+  }
+
+  return undefined;
+}
+
+function normalizeCurrency(value: unknown): { key: string; display: string } | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  return {
+    key: trimmed.toLowerCase(),
+    display: trimmed.toUpperCase(),
+  };
+}
+
+function assignNumberLike(
+  target: WalletBalanceInput,
+  field: keyof WalletBalanceUpdate,
+  value: unknown,
+): void {
+  if (value === null) {
+    (target as Record<string, unknown>)[field] = null;
+    return;
+  }
+
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    (target as Record<string, unknown>)[field] = value;
+  }
+}
+
+function groupByAccount(rows: NormalizedWalletRow[]): Map<string, WalletBalanceInput[]> {
+  const grouped = new Map<string, Map<string, NormalizedWalletRow>>();
+
+  for (const row of rows) {
+    let byCurrency = grouped.get(row.accountId);
+    if (!byCurrency) {
+      byCurrency = new Map();
+      grouped.set(row.accountId, byCurrency);
+    }
+
+    const existing = byCurrency.get(row.currencyKey);
+
+    if (!existing) {
+      byCurrency.set(row.currencyKey, row);
+      continue;
+    }
+
+    if (row.timestampMs !== undefined && existing.timestampMs !== undefined) {
+      if (row.timestampMs >= existing.timestampMs) {
+        byCurrency.set(row.currencyKey, row);
+      }
+      continue;
+    }
+
+    if (row.timestampMs !== undefined && existing.timestampMs === undefined) {
+      byCurrency.set(row.currencyKey, row);
+      continue;
+    }
+
+    if (row.timestampMs === undefined && existing.timestampMs === undefined) {
+      byCurrency.set(row.currencyKey, row);
+    }
+  }
+
+  const result = new Map<string, WalletBalanceInput[]>();
+
+  for (const [accountId, byCurrency] of grouped) {
+    const updates = Array.from(byCurrency.values())
+      .sort((a, b) => {
+        if (a.timestampMs === undefined && b.timestampMs === undefined) {
+          return 0;
+        }
+        if (a.timestampMs === undefined) {
+          return -1;
+        }
+        if (b.timestampMs === undefined) {
+          return 1;
+        }
+        return a.timestampMs - b.timestampMs;
+      })
+      .map((entry) => ({ ...entry.update }));
+
+    result.set(accountId, updates);
+  }
+
+  return result;
+}
+
+function recordMetrics(core: BitMex, updatedAt?: string): void {
+  const env: PrivateLabels['env'] = core.isTest ? 'testnet' : 'mainnet';
+  const labels: PrivateLabels = { env, table: 'wallet' };
+
+  incrementCounter(METRICS.walletUpdateCount, 1, labels);
+
+  if (!updatedAt) {
+    return;
+  }
+
+  const ageMs = Date.now() - parseIsoTs(updatedAt);
+  if (!Number.isFinite(ageMs)) {
+    return;
+  }
+
+  const ageSec = Math.max(0, ageMs / 1000);
+  observeHistogram(METRICS.snapshotAgeSec, ageSec, labels);
+}
+
+type LogContext = {
+  accountId: string;
+  existed: boolean;
+  action: 'partial' | 'insert' | 'update' | 'delete';
+  reason: string;
+  changed: readonly string[];
+  updatedAt?: string;
+};
+
+function logWalletUpdate(context: LogContext): void {
+  const { accountId, existed, action, reason, changed, updatedAt } = context;
+  const tags = existed && action === 'partial' ? [...BASE_TAGS, LOG_TAGS.reconnect] : BASE_TAGS;
+
+  if (action === 'partial') {
+    const message = existed
+      ? 'BitMEX wallet resync applied for account %s'
+      : 'BitMEX wallet snapshot applied for account %s';
+
+    log.debug(message, accountId, {
+      tags,
+      reason,
+      changed,
+      updatedAt: updatedAt ?? null,
+    });
+    return;
+  }
+
+  const messageMap: Record<Exclude<LogContext['action'], 'partial'>, string> = {
+    insert: 'BitMEX wallet insert processed for account %s',
+    update: 'BitMEX wallet update processed for account %s',
+    delete: 'BitMEX wallet delete processed for account %s',
+  };
+
+  log.debug(messageMap[action], accountId, {
+    tags,
+    reason,
+    changed,
+    updatedAt: updatedAt ?? null,
+  });
+}

--- a/src/domain/wallet.ts
+++ b/src/domain/wallet.ts
@@ -1,0 +1,246 @@
+import { EventEmitter } from 'node:events';
+
+import { diffKeys } from '../infra/diff.js';
+import { isNewerByTimestamp } from '../infra/time.js';
+
+import type { AccountId, BaseEntity, DomainUpdate, TimestampISO } from '../core/types.js';
+
+export type WalletBalanceValue = number | null;
+
+export type WalletBalanceSnapshot = {
+  currency: string;
+  amount?: WalletBalanceValue;
+  pendingCredit?: WalletBalanceValue;
+  pendingDebit?: WalletBalanceValue;
+  confirmedDebit?: WalletBalanceValue;
+  transferIn?: WalletBalanceValue;
+  transferOut?: WalletBalanceValue;
+  deposited?: WalletBalanceValue;
+  withdrawn?: WalletBalanceValue;
+  timestamp?: TimestampISO;
+};
+
+export type WalletSnapshot = {
+  accountId: AccountId;
+  balances: Record<string, WalletBalanceSnapshot>;
+  updatedAt?: TimestampISO;
+};
+
+export type WalletBalanceUpdate = Partial<Omit<WalletBalanceSnapshot, 'currency'>>;
+
+export type WalletBalanceInput = WalletBalanceUpdate & { currency: string };
+
+export type WalletApplyOptions = {
+  reason?: string;
+  reset?: boolean;
+};
+
+export class Wallet extends EventEmitter implements BaseEntity<WalletSnapshot> {
+  #accountId: AccountId;
+  #balances: Map<string, WalletBalanceSnapshot> = new Map();
+  #updatedAt?: TimestampISO;
+
+  constructor(accountId: AccountId) {
+    super();
+    this.#accountId = accountId;
+  }
+
+  get accountId(): AccountId {
+    return this.#accountId;
+  }
+
+  getSnapshot(): WalletSnapshot {
+    return this.#buildSnapshot(this.#balances, this.#updatedAt);
+  }
+
+  apply(updates: WalletBalanceInput[], options: WalletApplyOptions = {}): DomainUpdate<WalletSnapshot> | null {
+    const { reset = false, reason } = options;
+
+    if (!Array.isArray(updates) || (updates.length === 0 && !reset)) {
+      return null;
+    }
+
+    const prevSnapshot = this.getSnapshot();
+    const balances = reset ? new Map<string, WalletBalanceSnapshot>() : new Map(this.#balances);
+
+    for (const update of updates) {
+      if (!update || typeof update.currency !== 'string') {
+        continue;
+      }
+
+      const currencyKey = Wallet.#normalizeCurrencyKey(update.currency);
+      if (!currencyKey) {
+        continue;
+      }
+
+      const prevEntry = balances.get(currencyKey);
+      const fields = Wallet.#omitCurrency(update);
+      const nextEntry = prevEntry && !reset ? { ...prevEntry } : { currency: update.currency };
+
+      let entryChanged = reset || !prevEntry || prevEntry.currency !== update.currency;
+
+      const nextTimestamp = fields.timestamp;
+      const prevTimestamp = prevEntry?.timestamp;
+
+      if (
+        !reset &&
+        prevEntry &&
+        prevTimestamp &&
+        nextTimestamp &&
+        !isNewerByTimestamp(prevTimestamp, nextTimestamp)
+      ) {
+        continue;
+      }
+
+      for (const [key, value] of Object.entries(fields) as [
+        keyof WalletBalanceUpdate,
+        WalletBalanceUpdate[keyof WalletBalanceUpdate],
+      ][]) {
+        if (value === undefined) {
+          continue;
+        }
+
+        const current = (nextEntry as Record<string, unknown>)[key];
+
+        if (value === null) {
+          if (current !== null) {
+            (nextEntry as Record<string, unknown>)[key] = null;
+            entryChanged = true;
+          }
+          continue;
+        }
+
+        if (!Object.is(current, value)) {
+          (nextEntry as Record<string, unknown>)[key] = value;
+          entryChanged = true;
+        }
+      }
+
+      if (!entryChanged) {
+        continue;
+      }
+
+      balances.set(currencyKey, nextEntry);
+    }
+
+    const nextUpdatedAt = this.#calculateUpdatedAt(balances);
+    const nextSnapshot = this.#buildSnapshot(balances, nextUpdatedAt);
+    const changed = diffKeys(prevSnapshot, nextSnapshot);
+
+    if (changed.length === 0) {
+      return null;
+    }
+
+    this.#balances = balances;
+    this.#updatedAt = nextUpdatedAt;
+
+    const diff: DomainUpdate<WalletSnapshot> = { prev: prevSnapshot, next: nextSnapshot, changed };
+    this.emit('update', nextSnapshot, diff, reason);
+
+    return diff;
+  }
+
+  removeCurrencies(currencies: string[], reason?: string): DomainUpdate<WalletSnapshot> | null {
+    if (!Array.isArray(currencies) || currencies.length === 0) {
+      return null;
+    }
+
+    const prevSnapshot = this.getSnapshot();
+    const balances = new Map(this.#balances);
+    let mutated = false;
+
+    for (const currency of currencies) {
+      const currencyKey = Wallet.#normalizeCurrencyKey(currency);
+      if (!currencyKey) {
+        continue;
+      }
+
+      if (balances.delete(currencyKey)) {
+        mutated = true;
+      }
+    }
+
+    if (!mutated) {
+      return null;
+    }
+
+    const nextUpdatedAt = this.#calculateUpdatedAt(balances);
+    const nextSnapshot = this.#buildSnapshot(balances, nextUpdatedAt);
+    const changed = diffKeys(prevSnapshot, nextSnapshot);
+
+    if (changed.length === 0) {
+      return null;
+    }
+
+    this.#balances = balances;
+    this.#updatedAt = nextUpdatedAt;
+
+    const diff: DomainUpdate<WalletSnapshot> = { prev: prevSnapshot, next: nextSnapshot, changed };
+    this.emit('update', nextSnapshot, diff, reason);
+
+    return diff;
+  }
+
+  override on(
+    event: 'update',
+    listener: (next: WalletSnapshot, diff: DomainUpdate<WalletSnapshot>, reason?: string) => void,
+  ): this {
+    return super.on(event, listener);
+  }
+
+  override off(
+    event: 'update',
+    listener: (next: WalletSnapshot, diff: DomainUpdate<WalletSnapshot>, reason?: string) => void,
+  ): this {
+    return super.off(event, listener);
+  }
+
+  static #normalizeCurrencyKey(currency: string): string {
+    if (typeof currency !== 'string') {
+      return '';
+    }
+
+    const trimmed = currency.trim();
+    return trimmed.toLowerCase();
+  }
+
+  static #omitCurrency(update: WalletBalanceInput): WalletBalanceUpdate {
+    const { currency: _currency, ...rest } = update;
+    return rest;
+  }
+
+  #calculateUpdatedAt(balances: Map<string, WalletBalanceSnapshot>): TimestampISO | undefined {
+    let latest: TimestampISO | undefined;
+
+    for (const entry of balances.values()) {
+      const ts = entry.timestamp;
+      if (!ts) {
+        continue;
+      }
+
+      if (!latest || isNewerByTimestamp(latest, ts)) {
+        latest = ts;
+      }
+    }
+
+    return latest;
+  }
+
+  #buildSnapshot(
+    balances: Map<string, WalletBalanceSnapshot>,
+    updatedAt?: TimestampISO,
+  ): WalletSnapshot {
+    const entries = Array.from(balances.entries()).sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+    const normalizedBalances: Record<string, WalletBalanceSnapshot> = {};
+
+    for (const [key, entry] of entries) {
+      normalizedBalances[key] = { ...entry };
+    }
+
+    return {
+      accountId: this.#accountId,
+      balances: normalizedBalances,
+      ...(updatedAt ? { updatedAt } : {}),
+    };
+  }
+}

--- a/tests/integration/private/wallet-stream.test.ts
+++ b/tests/integration/private/wallet-stream.test.ts
@@ -1,0 +1,304 @@
+import type { BitMexChannelMessage, BitMexWallet } from '../../../src/core/bitmex/types.js';
+import type { DomainUpdate } from '../../../src/core/types.js';
+import type { WalletSnapshot } from '../../../src/domain/wallet.js';
+
+import { ExchangeHub } from '../../../src/ExchangeHub.js';
+import { METRICS } from '../../../src/infra/metrics-private.js';
+import { getCounterValue, getHistogramValues, resetMetrics } from '../../../src/infra/metrics.js';
+
+const ORIGINAL_WEBSOCKET = (globalThis as any).WebSocket;
+
+type WalletUpdateEvent = {
+  snapshot: WalletSnapshot;
+  diff: DomainUpdate<WalletSnapshot>;
+  reason?: string;
+};
+
+describe('BitMEX wallet stream', () => {
+  beforeAll(() => {
+    (globalThis as any).WebSocket = ControlledWebSocket;
+  });
+
+  afterAll(() => {
+    (globalThis as any).WebSocket = ORIGINAL_WEBSOCKET;
+  });
+
+  beforeEach(() => {
+    resetMetrics();
+    ControlledWebSocket.instances = [];
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test('partial snapshots, updates, duplicates, and resync keep wallet state consistent', async () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2024-01-01T00:00:05.000Z'));
+
+    const hub = new ExchangeHub('BitMex', { isTest: true });
+    const socket = ControlledWebSocket.instances[0];
+    expect(socket).toBeDefined();
+
+    const connectPromise = hub.connect();
+    socket!.simulateOpen();
+    await connectPromise;
+
+    const labels = { env: 'testnet', table: 'wallet' } as const;
+
+    const partialData: BitMexWallet[] = [
+      {
+        account: 12345,
+        currency: 'XBt',
+        amount: 1_000_000,
+        pendingCredit: 0,
+        pendingDebit: 0,
+        confirmedDebit: 0,
+        transferIn: 100,
+        transferOut: 0,
+        deposited: 100,
+        withdrawn: 0,
+        timestamp: '2024-01-01T00:00:00.000Z',
+      },
+    ];
+
+    socket!.simulateMessage(buildMessage('partial', partialData));
+
+    const wallet = hub.wallets.get('12345');
+    expect(wallet).toBeDefined();
+
+    const partialSnapshot = wallet!.getSnapshot();
+    expect(partialSnapshot).toEqual({
+      accountId: '12345',
+      balances: {
+        xbt: {
+          currency: 'XBT',
+          amount: 1_000_000,
+          pendingCredit: 0,
+          pendingDebit: 0,
+          confirmedDebit: 0,
+          transferIn: 100,
+          transferOut: 0,
+          deposited: 100,
+          withdrawn: 0,
+          timestamp: '2024-01-01T00:00:00.000Z',
+        },
+      },
+      updatedAt: '2024-01-01T00:00:00.000Z',
+    });
+
+    expect(getCounterValue(METRICS.walletUpdateCount, labels)).toBe(1);
+    expect(getHistogramValues(METRICS.snapshotAgeSec, labels)).toEqual([5]);
+
+    const events: WalletUpdateEvent[] = [];
+    const handler = (snapshot: WalletSnapshot, diff: DomainUpdate<WalletSnapshot>, reason?: string) => {
+      events.push({ snapshot, diff, reason });
+    };
+    wallet!.on('update', handler);
+
+    try {
+      jest.setSystemTime(new Date('2024-01-01T00:00:06.000Z'));
+
+      const updateData: BitMexWallet[] = [
+        {
+          account: 12345,
+          currency: 'XBt',
+          amount: 1_100_000,
+          transferIn: 150,
+          timestamp: '2024-01-01T00:00:02.000Z',
+        },
+      ];
+
+      socket!.simulateMessage(buildMessage('update', updateData));
+
+      expect(events).toHaveLength(1);
+      const firstUpdate = events[0];
+      expect(new Set(firstUpdate.diff.changed)).toEqual(new Set(['balances', 'updatedAt']));
+      expect(firstUpdate.reason).toBe('ws:update');
+      expect(firstUpdate.snapshot.balances.xbt.amount).toBe(1_100_000);
+      expect(firstUpdate.snapshot.balances.xbt.transferIn).toBe(150);
+      expect(firstUpdate.snapshot.updatedAt).toBe('2024-01-01T00:00:02.000Z');
+
+      expect(getCounterValue(METRICS.walletUpdateCount, labels)).toBe(2);
+      const histogramAfterUpdate = getHistogramValues(METRICS.snapshotAgeSec, labels);
+      expect(histogramAfterUpdate).toHaveLength(2);
+      expect(histogramAfterUpdate[1]).toBeCloseTo(4);
+
+      events.length = 0;
+
+      jest.setSystemTime(new Date('2024-01-01T00:00:07.000Z'));
+
+      const duplicateData: BitMexWallet[] = [
+        {
+          account: 12345,
+          currency: 'XBt',
+          amount: 1_100_000,
+          transferIn: 150,
+          timestamp: '2024-01-01T00:00:02.000Z',
+        },
+      ];
+
+      socket!.simulateMessage(buildMessage('update', duplicateData));
+
+      const staleData: BitMexWallet[] = [
+        {
+          account: 12345,
+          currency: 'XBt',
+          amount: 900_000,
+          timestamp: '2024-01-01T00:00:01.000Z',
+        },
+      ];
+
+      socket!.simulateMessage(buildMessage('update', staleData));
+
+      expect(events).toHaveLength(0);
+      expect(getCounterValue(METRICS.walletUpdateCount, labels)).toBe(2);
+
+      jest.setSystemTime(new Date('2024-01-01T00:05:05.000Z'));
+
+      const resyncPartial: BitMexWallet[] = [
+        {
+          account: 12345,
+          currency: 'XBt',
+          amount: 500_000,
+          deposited: 200,
+          withdrawn: 50,
+          timestamp: '2024-01-01T00:05:00.000Z',
+        },
+        {
+          account: 12345,
+          currency: 'USDT',
+          amount: 2_000,
+          pendingCredit: 10,
+          timestamp: '2024-01-01T00:05:00.000Z',
+        },
+      ];
+
+      socket!.simulateMessage(buildMessage('partial', resyncPartial));
+
+      expect(events).toHaveLength(1);
+      const resyncEvent = events[0];
+      expect(resyncEvent.reason).toBe('ws:resync');
+      expect(new Set(resyncEvent.diff.changed)).toEqual(new Set(['balances', 'updatedAt']));
+      expect(resyncEvent.snapshot.updatedAt).toBe('2024-01-01T00:05:00.000Z');
+      expect(resyncEvent.snapshot.balances).toMatchObject({
+        usdt: {
+          currency: 'USDT',
+          amount: 2_000,
+          pendingCredit: 10,
+          timestamp: '2024-01-01T00:05:00.000Z',
+        },
+        xbt: {
+          currency: 'XBT',
+          amount: 500_000,
+          deposited: 200,
+          withdrawn: 50,
+          timestamp: '2024-01-01T00:05:00.000Z',
+        },
+      });
+
+      expect(getCounterValue(METRICS.walletUpdateCount, labels)).toBe(3);
+      const histogramAfterResync = getHistogramValues(METRICS.snapshotAgeSec, labels);
+      expect(histogramAfterResync).toHaveLength(3);
+      expect(histogramAfterResync[2]).toBeCloseTo(5);
+
+      events.length = 0;
+
+      jest.setSystemTime(new Date('2024-01-01T00:05:06.000Z'));
+
+      const postResyncUpdate: BitMexWallet[] = [
+        {
+          account: 12345,
+          currency: 'USDT',
+          pendingCredit: 20,
+          timestamp: '2024-01-01T00:05:05.000Z',
+        },
+      ];
+
+      socket!.simulateMessage(buildMessage('update', postResyncUpdate));
+
+      expect(events).toHaveLength(1);
+      const finalEvent = events[0];
+      expect(finalEvent.reason).toBe('ws:update');
+      expect(new Set(finalEvent.diff.changed)).toEqual(new Set(['balances', 'updatedAt']));
+      expect(finalEvent.snapshot.balances.usdt.pendingCredit).toBe(20);
+      expect(finalEvent.snapshot.balances.xbt.amount).toBe(500_000);
+      expect(finalEvent.snapshot.updatedAt).toBe('2024-01-01T00:05:05.000Z');
+
+      expect(getCounterValue(METRICS.walletUpdateCount, labels)).toBe(4);
+      const histogramFinal = getHistogramValues(METRICS.snapshotAgeSec, labels);
+      expect(histogramFinal).toHaveLength(4);
+      expect(histogramFinal[3]).toBeCloseTo(1);
+    } finally {
+      wallet?.off('update', handler);
+      await hub.disconnect();
+    }
+  });
+});
+
+class ControlledWebSocket {
+  static instances: ControlledWebSocket[] = [];
+
+  public readonly url: string;
+  public onmessage: ((event: { data: unknown }) => void) | null = null;
+  public onopen: (() => void) | null = null;
+  public onerror: ((err: unknown) => void) | null = null;
+  public onclose: ((event?: { code?: number; reason?: string }) => void) | null = null;
+
+  #listeners = new Map<string, Set<(...args: unknown[]) => void>>();
+
+  constructor(url: string) {
+    this.url = url;
+    ControlledWebSocket.instances.push(this);
+  }
+
+  addEventListener(event: string, listener: (...args: unknown[]) => void): void {
+    if (!this.#listeners.has(event)) {
+      this.#listeners.set(event, new Set());
+    }
+
+    this.#listeners.get(event)!.add(listener);
+  }
+
+  removeEventListener(event: string, listener: (...args: unknown[]) => void): void {
+    this.#listeners.get(event)?.delete(listener);
+  }
+
+  send(_data: string): void {}
+
+  close(): void {
+    this.#emit('close', { code: 1000, reason: 'client-request' });
+  }
+
+  simulateOpen(): void {
+    this.#emit('open');
+  }
+
+  simulateMessage(message: BitMexChannelMessage<'wallet'>): void {
+    const payload = JSON.stringify(message);
+    this.#emit('message', { data: payload });
+  }
+
+  #emit(event: string, ...args: unknown[]): void {
+    const handler = (this as any)[`on${event}`];
+
+    if (typeof handler === 'function') {
+      handler(...args);
+    }
+
+    for (const listener of this.#listeners.get(event) ?? []) {
+      listener(...args);
+    }
+  }
+}
+
+function buildMessage(
+  action: BitMexChannelMessage<'wallet'>['action'],
+  data: BitMexWallet[],
+): BitMexChannelMessage<'wallet'> {
+  return {
+    table: 'wallet',
+    action,
+    data,
+  };
+}


### PR DESCRIPTION
## Summary
- add a Wallet domain entity implementing the BaseEntity contract with diff-driven events
- parse BitMEX wallet channel messages, normalize timestamps, dedupe stale rows, and emit metrics/logs
- expose wallet accessors on ExchangeHub and cover reconnect scenarios with an integration test

## Testing
- npm test -- wallet-stream

------
https://chatgpt.com/codex/tasks/task_e_68cd1e4e531883208a18ba89eab22d2d