### PR TITLE
feat: add BitMEX order stream with cache and fills

### DIFF
--- a/src/ExchangeHub.ts
+++ b/src/ExchangeHub.ts
@@ -1,5 +1,6 @@
 import { Cores } from './core/index.js';
 import { createEntities } from './entities/index.js';
+import { OrdersRegistry } from './core/exchange-hub.js';
 
 import type { BaseCore } from './core/BaseCore.js';
 import type { ExchangeName, Settings } from './types.js';
@@ -8,6 +9,7 @@ export class ExchangeHub<ExName extends ExchangeName> {
   #entities = createEntities(this);
   #core: BaseCore<ExName>;
   #isTest: boolean;
+  #orders = new OrdersRegistry();
 
   constructor(exchangeName: ExName, settings: Settings = {}) {
     const { isTest } = settings;
@@ -22,6 +24,10 @@ export class ExchangeHub<ExName extends ExchangeName> {
 
   get entities() {
     return this.#entities;
+  }
+
+  get orders(): OrdersRegistry {
+    return this.#orders;
   }
 
   get isTest(): boolean {

--- a/src/core/bitmex/channelMessageHandlers/order.ts
+++ b/src/core/bitmex/channelMessageHandlers/order.ts
@@ -1,20 +1,28 @@
+import { handleOrderMessage } from '../channels/order.js';
+
 import type { BitMex } from '../index.js';
-import type { BitMexOrder } from '../types.js';
+import type { BitMexChannelMessage } from '../types.js';
+
+type OrderMessage = BitMexChannelMessage<'order'>;
+
+function forward(core: BitMex, action: OrderMessage['action'], data: OrderMessage['data']): void {
+  handleOrderMessage(core, { table: 'order', action, data });
+}
 
 export const order = {
-  partial(_core: BitMex, _data: BitMexOrder[]) {
-    throw 'not implemented';
+  partial(core: BitMex, data: OrderMessage['data']) {
+    forward(core, 'partial', data);
   },
 
-  insert(_core: BitMex, _data: BitMexOrder[]) {
-    throw 'not implemented';
+  insert(core: BitMex, data: OrderMessage['data']) {
+    forward(core, 'insert', data);
   },
 
-  update(_core: BitMex, _data: BitMexOrder[]) {
-    throw 'not implemented';
+  update(core: BitMex, data: OrderMessage['data']) {
+    forward(core, 'update', data);
   },
 
-  delete(_core: BitMex, _data: BitMexOrder[]) {
-    throw 'not implemented';
+  delete(core: BitMex, data: OrderMessage['data']) {
+    forward(core, 'delete', data);
   },
 };

--- a/src/core/bitmex/channels/order.ts
+++ b/src/core/bitmex/channels/order.ts
@@ -1,0 +1,271 @@
+import { createLogger, LOG_TAGS } from '../../../infra/logger.js';
+import { mapBitmexOrderStatus } from '../mappers/order.js';
+
+import { OrderStatus, type OrderUpdate } from '../../../domain/order.js';
+
+import type { BitMex } from '../index.js';
+import type { BitMexChannelMessage, BitMexOrder } from '../types.js';
+
+const log = createLogger('bitmex:order').withTags([
+  LOG_TAGS.ws,
+  LOG_TAGS.private,
+  LOG_TAGS.order,
+]);
+
+export function handleOrderMessage(core: BitMex, message: BitMexChannelMessage<'order'>): void {
+  const { action, data } = message;
+
+  if (!Array.isArray(data) || data.length === 0) {
+    return;
+  }
+
+  switch (action) {
+    case 'partial':
+      processBatch(core, data, 'snapshot');
+      break;
+    case 'insert':
+      processBatch(core, data, 'insert');
+      break;
+    case 'update':
+      processBatch(core, data, 'update');
+      break;
+    default:
+      log.debug('BitMEX order action ignored: %s', action, { action });
+      break;
+  }
+}
+
+function processBatch(core: BitMex, rows: BitMexOrder[], reason: UpdateReason): void {
+  for (const row of rows) {
+    processRow(core, row, reason);
+  }
+}
+
+function processRow(core: BitMex, row: BitMexOrder, reason: UpdateReason): void {
+  if (!row) {
+    return;
+  }
+
+  const orderId = normalizeId(row.orderID);
+  const clOrdId = normalizeId(row.clOrdID);
+
+  if (!orderId && !clOrdId) {
+    log.debug('BitMEX order skipped: no identifiers', { row });
+    return;
+  }
+
+  const store = core.shell.orders;
+
+  let order = orderId ? store.getByOrderId(orderId) : undefined;
+
+  if (!order && clOrdId) {
+    order = store.getByClOrdId(clOrdId);
+  }
+
+  const symbol = normalizeSymbol(row.symbol);
+
+  if (!order && orderId) {
+    const initStatus = mapBitmexOrderStatus(row.ordStatus, row.execType) ?? OrderStatus.Placed;
+    order = store.create(orderId, {
+      clOrdId,
+      symbol: symbol ?? undefined,
+      status: initStatus,
+      side: normalizeSide(row.side),
+      qty: isFiniteNumber(row.orderQty) ? row.orderQty : undefined,
+      price: isFiniteNumber(row.price) ? row.price : undefined,
+      leavesQty: isFiniteNumber(row.leavesQty) ? row.leavesQty : undefined,
+      filledQty: isFiniteNumber(row.cumQty) ? row.cumQty : undefined,
+      avgFillPrice: isFiniteNumber(row.avgPx) ? row.avgPx : undefined,
+    });
+  }
+
+  if (!order) {
+    log.debug('BitMEX order update without known order', { orderId, clOrdId });
+    return;
+  }
+
+  const update: OrderUpdate = {};
+
+  if (clOrdId) {
+    update.clOrdId = clOrdId;
+  }
+
+  if (symbol) {
+    update.symbol = symbol;
+  }
+
+  const side = normalizeSide(row.side);
+  if (side) {
+    update.side = side;
+  }
+
+  const ordType = normalizeString(row.ordType);
+  if (ordType) {
+    update.type = ordType;
+  }
+
+  const timeInForce = normalizeString(row.timeInForce);
+  if (timeInForce) {
+    update.timeInForce = timeInForce;
+  }
+
+  const execInst = normalizeString(row.execInst);
+  if (execInst) {
+    update.execInst = execInst;
+  }
+
+  if (isFiniteNumber(row.price)) {
+    update.price = row.price;
+  }
+
+  if (isFiniteNumber(row.stopPx)) {
+    update.stopPrice = row.stopPx;
+  }
+
+  if (isFiniteNumber(row.orderQty)) {
+    update.qty = row.orderQty;
+  }
+
+  if (isFiniteNumber(row.leavesQty)) {
+    update.leavesQty = row.leavesQty;
+  }
+
+  if (isFiniteNumber(row.cumQty)) {
+    update.cumQty = row.cumQty;
+  }
+
+  if (isFiniteNumber(row.avgPx)) {
+    update.avgPx = row.avgPx;
+  }
+
+  const status = mapBitmexOrderStatus(row.ordStatus, row.execType);
+  if (status) {
+    update.status = status;
+  } else if (reason === 'insert' || reason === 'snapshot') {
+    update.status = OrderStatus.Placed;
+  }
+
+  const liquidity = mapLiquidity(row.lastLiquidityInd);
+  const execId = normalizeId(row.execID);
+  const lastQty = isFiniteNumber(row.lastQty) ? row.lastQty : undefined;
+  const lastPx = isFiniteNumber(row.lastPx) ? row.lastPx : undefined;
+  const execTs = normalizeTimestamp(row.transactTime ?? row.timestamp);
+
+  if (execId || lastQty !== undefined) {
+    update.execution = {
+      execId: execId ?? undefined,
+      qty: lastQty,
+      price: lastPx,
+      ts: execTs ?? undefined,
+      liquidity,
+    };
+  }
+
+  const lastUpdateTs = normalizeTimestamp(row.transactTime ?? row.timestamp);
+  if (lastUpdateTs !== null) {
+    update.lastUpdateTs = lastUpdateTs;
+  }
+
+  const text = normalizeString(row.text);
+  if (text) {
+    update.text = text;
+  }
+
+  const updateReason = resolveReason(reason, row.execType, status ?? update.status);
+
+  order.applyUpdate(update, { reason: updateReason });
+}
+
+type UpdateReason = 'snapshot' | 'insert' | 'update';
+
+function resolveReason(
+  base: UpdateReason,
+  execType: BitMexOrder['execType'],
+  status: OrderStatus | undefined,
+): string {
+  if (execType === 'Trade') {
+    return 'fill';
+  }
+
+  if (execType === 'Canceled') {
+    return 'cancel';
+  }
+
+  if (execType === 'Expired') {
+    return 'expire';
+  }
+
+  if (status === OrderStatus.Rejected) {
+    return 'rejected';
+  }
+
+  return base;
+}
+
+function normalizeId(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function normalizeSymbol(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function normalizeSide(value: unknown): 'buy' | 'sell' | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  if (normalized === 'buy' || normalized === 'sell') {
+    return normalized as 'buy' | 'sell';
+  }
+
+  return null;
+}
+
+function normalizeString(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+function normalizeTimestamp(value: unknown): number | null {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : null;
+  }
+
+  if (typeof value === 'string') {
+    const ts = Date.parse(value);
+    return Number.isFinite(ts) ? ts : null;
+  }
+
+  return null;
+}
+
+function mapLiquidity(value: BitMexOrder['lastLiquidityInd']): 'maker' | 'taker' | undefined {
+  switch (value) {
+    case 'AddedLiquidity':
+      return 'maker';
+    case 'RemovedLiquidity':
+      return 'taker';
+    default:
+      return undefined;
+  }
+}

--- a/src/core/bitmex/mappers/order.ts
+++ b/src/core/bitmex/mappers/order.ts
@@ -1,0 +1,104 @@
+import { OrderStatus } from '../../../domain/order.js';
+
+import type { BitMexExecType, BitMexOrderStatus } from '../types.js';
+
+export function mapBitmexOrderStatus(
+  ordStatus?: BitMexOrderStatus | null,
+  execType?: BitMexExecType | null,
+): OrderStatus | undefined {
+  const statusFromOrd = mapOrdStatus(ordStatus);
+
+  if (statusFromOrd && isTerminalStatus(statusFromOrd)) {
+    return statusFromOrd;
+  }
+
+  if (execType === 'Trade') {
+    if (statusFromOrd === OrderStatus.Filled) {
+      return OrderStatus.Filled;
+    }
+
+    if (statusFromOrd === OrderStatus.Canceled) {
+      return OrderStatus.Canceled;
+    }
+
+    if (statusFromOrd === OrderStatus.PartiallyFilled) {
+      return OrderStatus.PartiallyFilled;
+    }
+
+    if (statusFromOrd === OrderStatus.Placed) {
+      return OrderStatus.PartiallyFilled;
+    }
+
+    return OrderStatus.PartiallyFilled;
+  }
+
+  const statusFromExec = mapExecStatus(execType);
+
+  if (statusFromExec) {
+    if (statusFromExec === OrderStatus.Placed) {
+      return statusFromOrd ?? OrderStatus.Placed;
+    }
+
+    if (statusFromExec === OrderStatus.PartiallyFilled) {
+      return statusFromOrd ?? OrderStatus.PartiallyFilled;
+    }
+
+    return statusFromExec;
+  }
+
+  if (statusFromOrd) {
+    return statusFromOrd;
+  }
+
+  return undefined;
+}
+
+function mapOrdStatus(status?: BitMexOrderStatus | null): OrderStatus | undefined {
+  switch (status) {
+    case 'New':
+      return OrderStatus.Placed;
+    case 'PartiallyFilled':
+      return OrderStatus.PartiallyFilled;
+    case 'Filled':
+      return OrderStatus.Filled;
+    case 'Canceled':
+      return OrderStatus.Canceled;
+    case 'Rejected':
+      return OrderStatus.Rejected;
+    case 'Expired':
+      return OrderStatus.Expired;
+    case 'Triggered':
+      return OrderStatus.Placed;
+    default:
+      return undefined;
+  }
+}
+
+function mapExecStatus(execType?: BitMexExecType | null): OrderStatus | undefined {
+  switch (execType) {
+    case 'New':
+      return OrderStatus.Placed;
+    case 'Trade':
+      return OrderStatus.PartiallyFilled;
+    case 'Canceled':
+      return OrderStatus.Canceled;
+    case 'Expired':
+      return OrderStatus.Expired;
+    case 'Calculated':
+    case 'Restated':
+    case 'Settlement':
+    case 'Funding':
+      return undefined;
+    default:
+      return undefined;
+  }
+}
+
+function isTerminalStatus(status: OrderStatus): boolean {
+  return (
+    status === OrderStatus.Canceled ||
+    status === OrderStatus.Rejected ||
+    status === OrderStatus.Expired ||
+    status === OrderStatus.Filled
+  );
+}

--- a/src/core/bitmex/mappers/order.ts
+++ b/src/core/bitmex/mappers/order.ts
@@ -2,56 +2,70 @@ import { OrderStatus } from '../../../domain/order.js';
 
 import type { BitMexExecType, BitMexOrderStatus } from '../types.js';
 
-export function mapBitmexOrderStatus(
-  ordStatus?: BitMexOrderStatus | null,
-  execType?: BitMexExecType | null,
-): OrderStatus | undefined {
+export type BitmexOrderStatusInput = {
+  ordStatus?: BitMexOrderStatus | null;
+  execType?: BitMexExecType | null;
+  leavesQty?: number | null;
+  cumQty?: number | null;
+  previousStatus?: OrderStatus | null;
+};
+
+const STATUS_PRIORITY: Record<OrderStatus, number> = {
+  [OrderStatus.Filled]: 6,
+  [OrderStatus.PartiallyFilled]: 5,
+  [OrderStatus.Rejected]: 4,
+  [OrderStatus.Expired]: 3,
+  [OrderStatus.Canceled]: 3,
+  [OrderStatus.Canceling]: 2,
+  [OrderStatus.Placed]: 1,
+};
+
+export function mapBitmexOrderStatus({
+  ordStatus,
+  execType,
+  leavesQty,
+  cumQty,
+  previousStatus,
+}: BitmexOrderStatusInput): OrderStatus | undefined {
+  const normalizedLeaves = normalizeQuantity(leavesQty);
+  const normalizedCum = normalizeQuantity(cumQty);
+
   const statusFromOrd = mapOrdStatus(ordStatus);
+  const statusFromQty = mapStatusFromQuantities(normalizedCum, normalizedLeaves, statusFromOrd);
+  const statusFromExec = mapExecStatus(execType, {
+    ordStatus: statusFromOrd,
+    qtyStatus: statusFromQty,
+    cumQty: normalizedCum,
+    leavesQty: normalizedLeaves,
+  });
 
-  if (statusFromOrd && isTerminalStatus(statusFromOrd)) {
-    return statusFromOrd;
+  const candidates = [statusFromExec, statusFromOrd, statusFromQty].filter(
+    (status): status is OrderStatus => Boolean(status),
+  );
+
+  let next = pickHighestPriority(candidates);
+
+  if (previousStatus && isTerminal(previousStatus)) {
+    if (!next) {
+      return previousStatus;
+    }
+
+    if (!isTerminal(next)) {
+      return previousStatus;
+    }
+
+    if (STATUS_PRIORITY[next] < STATUS_PRIORITY[previousStatus]) {
+      return previousStatus;
+    }
   }
 
-  if (execType === 'Trade') {
-    if (statusFromOrd === OrderStatus.Filled) {
-      return OrderStatus.Filled;
-    }
-
-    if (statusFromOrd === OrderStatus.Canceled) {
-      return OrderStatus.Canceled;
-    }
-
-    if (statusFromOrd === OrderStatus.PartiallyFilled) {
-      return OrderStatus.PartiallyFilled;
-    }
-
-    if (statusFromOrd === OrderStatus.Placed) {
-      return OrderStatus.PartiallyFilled;
-    }
-
-    return OrderStatus.PartiallyFilled;
+  if (!next) {
+    return previousStatus ?? undefined;
   }
 
-  const statusFromExec = mapExecStatus(execType);
-
-  if (statusFromExec) {
-    if (statusFromExec === OrderStatus.Placed) {
-      return statusFromOrd ?? OrderStatus.Placed;
-    }
-
-    if (statusFromExec === OrderStatus.PartiallyFilled) {
-      return statusFromOrd ?? OrderStatus.PartiallyFilled;
-    }
-
-    return statusFromExec;
-  }
-
-  if (statusFromOrd) {
-    return statusFromOrd;
-  }
-
-  return undefined;
+  return next;
 }
+
 
 function mapOrdStatus(status?: BitMexOrderStatus | null): OrderStatus | undefined {
   switch (status) {
@@ -74,31 +88,123 @@ function mapOrdStatus(status?: BitMexOrderStatus | null): OrderStatus | undefine
   }
 }
 
-function mapExecStatus(execType?: BitMexExecType | null): OrderStatus | undefined {
+function mapExecStatus(
+  execType: BitMexExecType | undefined | null,
+  context: {
+    ordStatus?: OrderStatus;
+    qtyStatus?: OrderStatus;
+    cumQty: number | null;
+    leavesQty: number | null;
+  },
+): OrderStatus | undefined {
   switch (execType) {
-    case 'New':
-      return OrderStatus.Placed;
     case 'Trade':
+      if (
+        context.qtyStatus === OrderStatus.Filled ||
+        context.ordStatus === OrderStatus.Filled ||
+        isFilledByQuantities(context.cumQty, context.leavesQty)
+      ) {
+        return OrderStatus.Filled;
+      }
+
       return OrderStatus.PartiallyFilled;
     case 'Canceled':
+      if (context.ordStatus === OrderStatus.Filled || context.qtyStatus === OrderStatus.Filled) {
+        return OrderStatus.Filled;
+      }
+
       return OrderStatus.Canceled;
     case 'Expired':
       return OrderStatus.Expired;
-    case 'Calculated':
+    case 'New':
+      if (context.ordStatus === OrderStatus.PartiallyFilled || context.qtyStatus === OrderStatus.PartiallyFilled) {
+        return OrderStatus.PartiallyFilled;
+      }
+
+      return OrderStatus.Placed;
     case 'Restated':
-    case 'Settlement':
-    case 'Funding':
+    case 'Calculated':
+      if (context.ordStatus === OrderStatus.Filled || context.qtyStatus === OrderStatus.Filled) {
+        return OrderStatus.Filled;
+      }
+
+      if (
+        context.ordStatus === OrderStatus.PartiallyFilled ||
+        context.qtyStatus === OrderStatus.PartiallyFilled
+      ) {
+        return OrderStatus.PartiallyFilled;
+      }
+
       return undefined;
+    case 'Settlement':
+      if (context.ordStatus === OrderStatus.Filled || context.qtyStatus === OrderStatus.Filled) {
+        return OrderStatus.Filled;
+      }
+
+      return undefined;
+    case 'Funding':
     default:
       return undefined;
   }
 }
 
-function isTerminalStatus(status: OrderStatus): boolean {
+function mapStatusFromQuantities(
+  cumQty: number | null,
+  leavesQty: number | null,
+  statusFromOrd?: OrderStatus,
+): OrderStatus | undefined {
+  if (isFilledByQuantities(cumQty, leavesQty)) {
+    return OrderStatus.Filled;
+  }
+
+  if (cumQty !== null && cumQty > 0) {
+    return OrderStatus.PartiallyFilled;
+  }
+
+  if (statusFromOrd === OrderStatus.PartiallyFilled && leavesQty !== null && leavesQty <= 0) {
+    return OrderStatus.PartiallyFilled;
+  }
+
+  if (statusFromOrd === OrderStatus.Filled) {
+    return OrderStatus.Filled;
+  }
+
+  return undefined;
+}
+
+function isFilledByQuantities(cumQty: number | null, leavesQty: number | null): boolean {
+  return cumQty !== null && cumQty > 0 && (leavesQty !== null ? leavesQty <= 0 : false);
+}
+
+function normalizeQuantity(value: number | null | undefined): number | null {
+  if (typeof value !== 'number') {
+    return null;
+  }
+
+  if (!Number.isFinite(value)) {
+    return null;
+  }
+
+  return value <= 0 ? 0 : value;
+}
+
+function pickHighestPriority(statuses: OrderStatus[]): OrderStatus | undefined {
+  let current: OrderStatus | undefined;
+
+  for (const status of statuses) {
+    if (!current || STATUS_PRIORITY[status] > STATUS_PRIORITY[current]) {
+      current = status;
+    }
+  }
+
+  return current;
+}
+
+function isTerminal(status: OrderStatus): boolean {
   return (
-    status === OrderStatus.Canceled ||
+    status === OrderStatus.Filled ||
     status === OrderStatus.Rejected ||
     status === OrderStatus.Expired ||
-    status === OrderStatus.Filled
+    status === OrderStatus.Canceled
   );
 }

--- a/src/core/bitmex/types.ts
+++ b/src/core/bitmex/types.ts
@@ -334,6 +334,7 @@ export type BitMexExecution = {
 
 export type BitMexOrder = {
   orderID: string;
+  execID?: string;
   clOrdID?: string;
   clOrdLinkID?: string;
   account?: number;
@@ -352,6 +353,7 @@ export type BitMexOrder = {
   timeInForce?: BitMexTimeInForce;
   execInst?: BitMexExecInst;
   contingencyType?: BitMexContingencyType;
+  execType?: BitMexExecType;
   ordStatus?: BitMexOrderStatus;
   triggered?: string;
   workingIndicator?: boolean;
@@ -359,12 +361,17 @@ export type BitMexOrder = {
   leavesQty?: number;
   cumQty?: number;
   avgPx?: number;
+  lastPx?: number;
+  lastQty?: number;
+  lastLiquidityInd?: BitMexLastLiquidityInd;
+  commission?: number;
   multiLegReportingType?: string;
   text?: string;
   transactTime?: string;
   timestamp?: string;
   simpleLeavesQty?: number;
   simpleCumQty?: number;
+  trdMatchID?: string;
 };
 
 export type BitMexMargin = {

--- a/src/core/exchange-hub.ts
+++ b/src/core/exchange-hub.ts
@@ -1,0 +1,293 @@
+import { Order, OrderStatus, type OrderInit } from '../domain/order.js';
+
+import type { ClOrdID, OrderID, Symbol } from './types.js';
+import type { DomainUpdate } from './types.js';
+
+type OrderListener = (
+  snapshot: ReturnType<Order['getSnapshot']>,
+  diff: DomainUpdate<ReturnType<Order['getSnapshot']>>,
+  reason?: string,
+) => void;
+
+export class OrdersRegistry {
+  #byOrderId = new Map<OrderID, Order>();
+  #byClOrdId = new Map<string, Order>();
+  #bySymbol = new Map<string, Set<Order>>();
+  #activeOrders = new Set<Order>();
+  #activeBySymbol = new Map<string, Set<Order>>();
+  #listeners = new Map<Order, OrderListener>();
+
+  get size(): number {
+    return this.#byOrderId.size;
+  }
+
+  values(): Order[] {
+    return Array.from(this.#byOrderId.values());
+  }
+
+  getByOrderId(orderId: OrderID | null | undefined): Order | undefined {
+    if (typeof orderId !== 'string') {
+      return undefined;
+    }
+
+    return this.#byOrderId.get(orderId);
+  }
+
+  getByClOrdId(clOrdId: ClOrdID | null | undefined): Order | undefined {
+    const key = normalizeClOrdId(clOrdId);
+    return key ? this.#byClOrdId.get(key) : undefined;
+  }
+
+  getBySymbol(symbol: Symbol | null | undefined): Order[] {
+    const key = normalizeSymbolKey(symbol);
+    if (!key) {
+      return [];
+    }
+
+    return Array.from(this.#bySymbol.get(key) ?? []);
+  }
+
+  getActiveOrders(): Order[] {
+    return Array.from(this.#activeOrders);
+  }
+
+  getActiveBySymbol(symbol: Symbol | null | undefined): Order[] {
+    const key = normalizeSymbolKey(symbol);
+    if (!key) {
+      return [];
+    }
+
+    return Array.from(this.#activeBySymbol.get(key) ?? []);
+  }
+
+  resolve(orderId: OrderID | null | undefined, clOrdId: ClOrdID | null | undefined): Order | undefined {
+    const byId = this.getByOrderId(orderId);
+    if (byId) {
+      return byId;
+    }
+
+    return this.getByClOrdId(clOrdId);
+  }
+
+  create(orderId: OrderID, init: Omit<OrderInit, 'orderId'> = {}): Order {
+    const existing = this.#byOrderId.get(orderId);
+    if (existing) {
+      return existing;
+    }
+
+    const order = new Order({ ...init, orderId });
+    this.#register(order);
+    return order;
+  }
+
+  delete(orderId: OrderID): boolean {
+    const order = this.#byOrderId.get(orderId);
+    if (!order) {
+      return false;
+    }
+
+    this.#byOrderId.delete(orderId);
+    this.#removeIndexes(order);
+    return true;
+  }
+
+  clear(): void {
+    for (const order of this.#byOrderId.values()) {
+      this.#detach(order);
+    }
+
+    this.#byOrderId.clear();
+    this.#byClOrdId.clear();
+    this.#bySymbol.clear();
+    this.#activeOrders.clear();
+    this.#activeBySymbol.clear();
+  }
+
+  #register(order: Order): void {
+    this.#byOrderId.set(order.orderId, order);
+    this.#index(order, order.getSnapshot());
+
+    const listener: OrderListener = (snapshot, diff) => {
+      this.#handleOrderUpdate(order, snapshot, diff);
+    };
+
+    order.on('update', listener);
+    this.#listeners.set(order, listener);
+  }
+
+  #removeIndexes(order: Order): void {
+    const listener = this.#listeners.get(order);
+    if (listener) {
+      order.off('update', listener);
+      this.#listeners.delete(order);
+    }
+
+    const snapshot = order.getSnapshot();
+    const clOrdKey = normalizeClOrdId(snapshot.clOrdId);
+    if (clOrdKey && this.#byClOrdId.get(clOrdKey) === order) {
+      this.#byClOrdId.delete(clOrdKey);
+    }
+
+    const symbolKey = normalizeSymbolKey(snapshot.symbol);
+    if (symbolKey) {
+      this.#bySymbol.get(symbolKey)?.delete(order);
+      if (this.#bySymbol.get(symbolKey)?.size === 0) {
+        this.#bySymbol.delete(symbolKey);
+      }
+    }
+
+    this.#activeOrders.delete(order);
+
+    if (symbolKey) {
+      this.#activeBySymbol.get(symbolKey)?.delete(order);
+      if (this.#activeBySymbol.get(symbolKey)?.size === 0) {
+        this.#activeBySymbol.delete(symbolKey);
+      }
+    }
+  }
+
+  #index(order: Order, snapshot: ReturnType<Order['getSnapshot']>): void {
+    const clOrdKey = normalizeClOrdId(snapshot.clOrdId);
+    if (clOrdKey) {
+      this.#byClOrdId.set(clOrdKey, order);
+    }
+
+    const symbolKey = normalizeSymbolKey(snapshot.symbol);
+    if (symbolKey) {
+      if (!this.#bySymbol.has(symbolKey)) {
+        this.#bySymbol.set(symbolKey, new Set());
+      }
+      this.#bySymbol.get(symbolKey)!.add(order);
+    }
+
+    if (isActiveStatus(snapshot.status)) {
+      this.#activeOrders.add(order);
+
+      if (symbolKey) {
+        if (!this.#activeBySymbol.has(symbolKey)) {
+          this.#activeBySymbol.set(symbolKey, new Set());
+        }
+        this.#activeBySymbol.get(symbolKey)!.add(order);
+      }
+    }
+  }
+
+  #handleOrderUpdate(
+    order: Order,
+    snapshot: ReturnType<Order['getSnapshot']>,
+    diff: DomainUpdate<ReturnType<Order['getSnapshot']>>,
+  ): void {
+    if (diff.changed.includes('clOrdId')) {
+      this.#reindexClOrd(order, diff.prev.clOrdId, snapshot.clOrdId);
+    }
+
+    if (diff.changed.includes('symbol')) {
+      this.#reindexSymbol(order, diff.prev.symbol, snapshot.symbol);
+    }
+
+    if (diff.changed.includes('status') || diff.changed.includes('symbol')) {
+      this.#reindexActive(order, diff.prev.symbol, diff.prev.status, snapshot.symbol, snapshot.status);
+    }
+  }
+
+  #reindexClOrd(order: Order, prev: ClOrdID | null, next: ClOrdID | null): void {
+    const prevKey = normalizeClOrdId(prev);
+    if (prevKey && this.#byClOrdId.get(prevKey) === order) {
+      this.#byClOrdId.delete(prevKey);
+    }
+
+    const nextKey = normalizeClOrdId(next);
+    if (nextKey) {
+      this.#byClOrdId.set(nextKey, order);
+    }
+  }
+
+  #reindexSymbol(order: Order, prev: Symbol, next: Symbol): void {
+    const prevKey = normalizeSymbolKey(prev);
+    if (prevKey) {
+      this.#bySymbol.get(prevKey)?.delete(order);
+      if (this.#bySymbol.get(prevKey)?.size === 0) {
+        this.#bySymbol.delete(prevKey);
+      }
+    }
+
+    const nextKey = normalizeSymbolKey(next);
+    if (nextKey) {
+      if (!this.#bySymbol.has(nextKey)) {
+        this.#bySymbol.set(nextKey, new Set());
+      }
+      this.#bySymbol.get(nextKey)!.add(order);
+    }
+  }
+
+  #reindexActive(
+    order: Order,
+    prevSymbol: Symbol,
+    prevStatus: OrderStatus,
+    nextSymbol: Symbol,
+    nextStatus: OrderStatus,
+  ): void {
+    const prevKey = normalizeSymbolKey(prevSymbol);
+    const nextKey = normalizeSymbolKey(nextSymbol);
+
+    if (isActiveStatus(prevStatus)) {
+      this.#activeOrders.delete(order);
+
+      if (prevKey) {
+        this.#activeBySymbol.get(prevKey)?.delete(order);
+        if (this.#activeBySymbol.get(prevKey)?.size === 0) {
+          this.#activeBySymbol.delete(prevKey);
+        }
+      }
+    }
+
+    if (isActiveStatus(nextStatus)) {
+      this.#activeOrders.add(order);
+
+      if (nextKey) {
+        if (!this.#activeBySymbol.has(nextKey)) {
+          this.#activeBySymbol.set(nextKey, new Set());
+        }
+        this.#activeBySymbol.get(nextKey)!.add(order);
+      }
+    }
+  }
+
+  #detach(order: Order): void {
+    const listener = this.#listeners.get(order);
+    if (listener) {
+      order.off('update', listener);
+      this.#listeners.delete(order);
+    }
+  }
+}
+
+export function isActiveStatus(status: OrderStatus): boolean {
+  return (
+    status === OrderStatus.Placed ||
+    status === OrderStatus.PartiallyFilled ||
+    status === OrderStatus.Canceling
+  );
+}
+
+function normalizeClOrdId(value: ClOrdID | null | undefined): string | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function normalizeSymbolKey(symbol: Symbol | null | undefined): string | null {
+  if (typeof symbol !== 'string') {
+    return null;
+  }
+
+  const trimmed = symbol.trim();
+  if (trimmed.length === 0) {
+    return null;
+  }
+
+  return trimmed.toUpperCase();
+}

--- a/src/domain/order.ts
+++ b/src/domain/order.ts
@@ -1,0 +1,609 @@
+import { EventEmitter } from 'node:events';
+
+import type {
+  BaseEntity,
+  ClOrdID,
+  DomainUpdate,
+  Liquidity,
+  OrderID,
+  Symbol,
+} from '../core/types.js';
+import type { Side } from '../types.js';
+
+export enum OrderStatus {
+  Placed = 'placed',
+  PartiallyFilled = 'partiallyFilled',
+  Filled = 'filled',
+  Canceling = 'canceling',
+  Canceled = 'canceled',
+  Rejected = 'rejected',
+  Expired = 'expired',
+}
+
+export type Execution = {
+  execId: string;
+  ts: number;
+  qty: number;
+  price: number;
+  liquidity?: Liquidity;
+};
+
+export type ExecutionUpdate = {
+  execId?: string | null;
+  ts?: number | string | null;
+  qty?: number | null;
+  price?: number | null;
+  liquidity?: Liquidity | null;
+};
+
+export type OrderSnapshot = {
+  orderId: OrderID;
+  clOrdId: ClOrdID | null;
+  symbol: Symbol;
+  status: OrderStatus;
+  side: Side | null;
+  type: string | null;
+  timeInForce: string | null;
+  execInst: string | null;
+  price: number | null;
+  stopPrice: number | null;
+  qty: number | null;
+  leavesQty: number | null;
+  filledQty: number;
+  avgFillPrice: number | null;
+  text: string | null;
+  lastUpdateTs: number | null;
+  executions: Execution[];
+};
+
+export type OrderInit = Partial<
+  Omit<OrderSnapshot, 'orderId' | 'executions' | 'filledQty' | 'avgFillPrice'>
+> & {
+  orderId: OrderID;
+  symbol?: Symbol | null;
+  status?: OrderStatus;
+  filledQty?: number | null;
+  avgFillPrice?: number | null;
+};
+
+export type OrderUpdate = Partial<
+  Omit<OrderSnapshot, 'orderId' | 'executions' | 'filledQty' | 'avgFillPrice'>
+> & {
+  cumQty?: number | null;
+  avgPx?: number | null;
+  execution?: ExecutionUpdate | null;
+};
+
+export type OrderUpdateContext = {
+  reason?: string;
+  silent?: boolean;
+};
+
+export class Order extends EventEmitter implements BaseEntity<OrderSnapshot> {
+  readonly orderId: OrderID;
+
+  #clOrdId: ClOrdID | null = null;
+  #symbol: Symbol;
+  #status: OrderStatus;
+  #side: Side | null = null;
+  #type: string | null = null;
+  #timeInForce: string | null = null;
+  #execInst: string | null = null;
+  #price: number | null = null;
+  #stopPrice: number | null = null;
+  #qty: number | null = null;
+  #leavesQty: number | null = null;
+  #text: string | null = null;
+  #lastUpdateTs: number | null = null;
+
+  #filledQty = 0;
+  #avgFillPrice: number | null = null;
+  #fillValue = 0;
+  #executions: Execution[] = [];
+  #executionIds = new Set<string>();
+
+  constructor(init: OrderInit) {
+    super();
+
+    const {
+      orderId,
+      clOrdId,
+      symbol,
+      status,
+      side,
+      type,
+      timeInForce,
+      execInst,
+      price,
+      stopPrice,
+      qty,
+      leavesQty,
+      text,
+      lastUpdateTs,
+      filledQty,
+      avgFillPrice,
+    } = init;
+
+    if (typeof orderId !== 'string' || orderId.trim().length === 0) {
+      throw new TypeError('Order requires a non-empty orderId');
+    }
+
+    this.orderId = orderId.trim();
+    this.#clOrdId = normalizeId(clOrdId);
+    this.#symbol = normalizeSymbol(symbol);
+    this.#status = status ?? OrderStatus.Placed;
+    this.#side = normalizeSide(side);
+    this.#type = normalizeString(type);
+    this.#timeInForce = normalizeString(timeInForce);
+    this.#execInst = normalizeString(execInst);
+    this.#price = normalizeOptionalNumber(price);
+    this.#stopPrice = normalizeOptionalNumber(stopPrice);
+    this.#qty = normalizeOptionalNumber(qty);
+    this.#leavesQty = normalizeOptionalNumber(leavesQty);
+    this.#text = normalizeString(text);
+    this.#lastUpdateTs = normalizeTimestamp(lastUpdateTs);
+
+    const initialFilled = normalizeQuantity(filledQty);
+    if (initialFilled !== null) {
+      this.#filledQty = initialFilled;
+    }
+
+    const initialAvg = normalizeOptionalNumber(avgFillPrice);
+    if (initialAvg !== null && this.#filledQty > 0) {
+      this.#avgFillPrice = initialAvg;
+      this.#fillValue = initialAvg * this.#filledQty;
+    } else if (this.#filledQty === 0) {
+      this.#avgFillPrice = null;
+      this.#fillValue = 0;
+    }
+  }
+
+  get clOrdId(): ClOrdID | null {
+    return this.#clOrdId;
+  }
+
+  get symbol(): Symbol {
+    return this.#symbol;
+  }
+
+  get status(): OrderStatus {
+    return this.#status;
+  }
+
+  get filledQty(): number {
+    return this.#filledQty;
+  }
+
+  get avgFillPrice(): number | null {
+    return this.#avgFillPrice;
+  }
+
+  getSnapshot(): OrderSnapshot {
+    return {
+      orderId: this.orderId,
+      clOrdId: this.#clOrdId,
+      symbol: this.#symbol,
+      status: this.#status,
+      side: this.#side,
+      type: this.#type,
+      timeInForce: this.#timeInForce,
+      execInst: this.#execInst,
+      price: this.#price,
+      stopPrice: this.#stopPrice,
+      qty: this.#qty,
+      leavesQty: this.#leavesQty,
+      filledQty: this.#filledQty,
+      avgFillPrice: this.#avgFillPrice,
+      text: this.#text,
+      lastUpdateTs: this.#lastUpdateTs,
+      executions: this.#executions.map((execution) => ({ ...execution })),
+    };
+  }
+
+  applyUpdate(update: OrderUpdate = {}, context: OrderUpdateContext = {}): DomainUpdate<OrderSnapshot> | null {
+    const { reason, silent = false } = context;
+    const prevSnapshot = this.getSnapshot();
+    const changed = new Set<keyof OrderSnapshot>();
+
+    if ('clOrdId' in update) {
+      const next = normalizeId(update.clOrdId);
+      if (!Object.is(this.#clOrdId, next)) {
+        this.#clOrdId = next;
+        changed.add('clOrdId');
+      }
+    }
+
+    if ('symbol' in update) {
+      const next = normalizeSymbol(update.symbol);
+      if (!Object.is(this.#symbol, next)) {
+        this.#symbol = next;
+        changed.add('symbol');
+      }
+    }
+
+    if ('side' in update) {
+      const next = normalizeSide(update.side);
+      if (!Object.is(this.#side, next)) {
+        this.#side = next;
+        changed.add('side');
+      }
+    }
+
+    if ('type' in update) {
+      const next = normalizeString(update.type);
+      if (!Object.is(this.#type, next)) {
+        this.#type = next;
+        changed.add('type');
+      }
+    }
+
+    if ('timeInForce' in update) {
+      const next = normalizeString(update.timeInForce);
+      if (!Object.is(this.#timeInForce, next)) {
+        this.#timeInForce = next;
+        changed.add('timeInForce');
+      }
+    }
+
+    if ('execInst' in update) {
+      const next = normalizeString(update.execInst);
+      if (!Object.is(this.#execInst, next)) {
+        this.#execInst = next;
+        changed.add('execInst');
+      }
+    }
+
+    if ('price' in update) {
+      const next = normalizeOptionalNumber(update.price);
+      if (!Object.is(this.#price, next)) {
+        this.#price = next;
+        changed.add('price');
+      }
+    }
+
+    if ('stopPrice' in update) {
+      const next = normalizeOptionalNumber(update.stopPrice);
+      if (!Object.is(this.#stopPrice, next)) {
+        this.#stopPrice = next;
+        changed.add('stopPrice');
+      }
+    }
+
+    if ('qty' in update) {
+      const next = normalizeOptionalNumber(update.qty);
+      if (!Object.is(this.#qty, next)) {
+        this.#qty = next;
+        changed.add('qty');
+      }
+    }
+
+    if ('leavesQty' in update) {
+      const next = normalizeOptionalNumber(update.leavesQty);
+      if (!Object.is(this.#leavesQty, next)) {
+        this.#leavesQty = next;
+        changed.add('leavesQty');
+      }
+    }
+
+    if ('text' in update) {
+      const next = normalizeString(update.text);
+      if (!Object.is(this.#text, next)) {
+        this.#text = next;
+        changed.add('text');
+      }
+    }
+
+    if ('lastUpdateTs' in update) {
+      const next = normalizeTimestamp(update.lastUpdateTs);
+      if (!Object.is(this.#lastUpdateTs, next)) {
+        this.#lastUpdateTs = next;
+        changed.add('lastUpdateTs');
+      }
+    }
+
+    if ('status' in update && update.status) {
+      if (!Object.is(this.#status, update.status)) {
+        this.#status = update.status;
+        changed.add('status');
+      }
+    }
+
+    const executionResult = this.#recordExecution(update);
+
+    if (executionResult.qtyDelta > 0) {
+      const nextFilled = this.#filledQty + executionResult.qtyDelta;
+      if (!Object.is(this.#filledQty, nextFilled)) {
+        this.#filledQty = nextFilled;
+        changed.add('filledQty');
+      }
+
+      const nextValue = this.#fillValue + executionResult.valueDelta;
+      if (!Number.isNaN(nextValue) && !Object.is(this.#fillValue, nextValue)) {
+        this.#fillValue = nextValue;
+      }
+
+      const nextAvg = this.#filledQty > 0 ? this.#fillValue / this.#filledQty : null;
+      if (!Object.is(this.#avgFillPrice, nextAvg)) {
+        this.#avgFillPrice = nextAvg;
+        changed.add('avgFillPrice');
+      }
+    }
+
+    if (executionResult.added) {
+      changed.add('executions');
+    }
+
+    let cumQtyProvided = false;
+    let normalizedCumQty: number | null = null;
+    if ('cumQty' in update) {
+      cumQtyProvided = true;
+      normalizedCumQty = normalizeQuantity(update.cumQty);
+
+      if (normalizedCumQty !== null && !Object.is(this.#filledQty, normalizedCumQty)) {
+        this.#filledQty = normalizedCumQty;
+        changed.add('filledQty');
+      }
+    }
+
+    let avgPxProvided = false;
+    let normalizedAvgPx: number | null = null;
+    if ('avgPx' in update) {
+      avgPxProvided = true;
+      normalizedAvgPx = normalizeOptionalNumber(update.avgPx);
+    }
+
+    if (cumQtyProvided) {
+      const currentFilled = this.#filledQty;
+      if (currentFilled <= 0) {
+        this.#filledQty = 0;
+        this.#fillValue = 0;
+        if (this.#avgFillPrice !== null) {
+          this.#avgFillPrice = null;
+          changed.add('avgFillPrice');
+        }
+      } else {
+        let nextAvg = this.#avgFillPrice;
+        if (avgPxProvided && normalizedAvgPx !== null) {
+          nextAvg = normalizedAvgPx;
+        }
+
+        if (nextAvg !== null) {
+          const nextValue = nextAvg * currentFilled;
+          if (!Object.is(this.#fillValue, nextValue)) {
+            this.#fillValue = nextValue;
+          }
+          if (!Object.is(this.#avgFillPrice, nextAvg)) {
+            this.#avgFillPrice = nextAvg;
+            changed.add('avgFillPrice');
+          }
+        } else if (this.#fillValue > 0) {
+          const derivedAvg = this.#fillValue / currentFilled;
+          if (!Object.is(this.#avgFillPrice, derivedAvg)) {
+            this.#avgFillPrice = derivedAvg;
+            changed.add('avgFillPrice');
+          }
+        }
+      }
+    } else if (avgPxProvided && normalizedAvgPx !== null && this.#filledQty > 0) {
+      const nextValue = normalizedAvgPx * this.#filledQty;
+      if (!Object.is(this.#fillValue, nextValue)) {
+        this.#fillValue = nextValue;
+      }
+      if (!Object.is(this.#avgFillPrice, normalizedAvgPx)) {
+        this.#avgFillPrice = normalizedAvgPx;
+        changed.add('avgFillPrice');
+      }
+    }
+
+    if (this.#filledQty === 0) {
+      if (this.#avgFillPrice !== null) {
+        this.#avgFillPrice = null;
+        changed.add('avgFillPrice');
+      }
+      if (this.#fillValue !== 0) {
+        this.#fillValue = 0;
+      }
+    }
+
+    if (changed.size === 0) {
+      return null;
+    }
+
+    const nextSnapshot = this.getSnapshot();
+    const diff: DomainUpdate<OrderSnapshot> = {
+      prev: prevSnapshot,
+      next: nextSnapshot,
+      changed: Array.from(changed),
+    };
+
+    if (!silent) {
+      this.emit('update', nextSnapshot, diff, reason);
+    }
+
+    return diff;
+  }
+
+  markCanceling(reason?: string): DomainUpdate<OrderSnapshot> | null {
+    if (this.#status === OrderStatus.Canceling) {
+      return null;
+    }
+
+    return this.applyUpdate({ status: OrderStatus.Canceling }, { reason: reason ?? 'canceling' });
+  }
+
+  #recordExecution(update: OrderUpdate): { added: boolean; qtyDelta: number; valueDelta: number } {
+    const exec = update.execution;
+    if (!exec) {
+      return { added: false, qtyDelta: 0, valueDelta: 0 };
+    }
+
+    const execId = normalizeId(exec.execId);
+
+    if (!execId) {
+      return { added: false, qtyDelta: 0, valueDelta: 0 };
+    }
+
+    if (this.#executionIds.has(execId)) {
+      return { added: false, qtyDelta: 0, valueDelta: 0 };
+    }
+
+    let qty = normalizeQuantity(exec.qty);
+    if ((qty === null || qty === 0) && 'cumQty' in update) {
+      const normalizedCum = normalizeQuantity(update.cumQty);
+      if (normalizedCum !== null) {
+        const diff = normalizedCum - this.#filledQty;
+        if (Number.isFinite(diff) && diff > 0) {
+          qty = diff;
+        }
+      }
+    }
+
+    if (qty === null || qty <= 0) {
+      this.#executionIds.add(execId);
+      return { added: false, qtyDelta: 0, valueDelta: 0 };
+    }
+
+    let price = normalizeOptionalNumber(exec.price);
+    if (price === null) {
+      if ('avgPx' in update) {
+        const normalizedAvgPx = normalizeOptionalNumber(update.avgPx);
+        if (normalizedAvgPx !== null) {
+          price = normalizedAvgPx;
+        }
+      }
+
+      if (price === null && this.#avgFillPrice !== null) {
+        price = this.#avgFillPrice;
+      }
+    }
+
+    if (price === null) {
+      price = 0;
+    }
+
+    const ts = normalizeTimestamp(exec.ts) ?? Date.now();
+    const liquidity = exec.liquidity ?? undefined;
+
+    const execution: Execution = {
+      execId,
+      qty,
+      price,
+      ts,
+      ...(liquidity ? { liquidity } : {}),
+    };
+
+    this.#executionIds.add(execId);
+    this.#executions.push(execution);
+
+    const valueDelta = price * qty;
+
+    return { added: true, qtyDelta: qty, valueDelta };
+  }
+
+  public override on(
+    event: 'update',
+    listener: (snapshot: OrderSnapshot, diff: DomainUpdate<OrderSnapshot>, reason?: string) => void,
+  ): this;
+  public override on(event: string | symbol, listener: (...args: any[]) => void): this;
+  public override on(event: string | symbol, listener: (...args: any[]) => void): this {
+    return super.on(event, listener);
+  }
+
+  public override once(
+    event: 'update',
+    listener: (snapshot: OrderSnapshot, diff: DomainUpdate<OrderSnapshot>, reason?: string) => void,
+  ): this;
+  public override once(event: string | symbol, listener: (...args: any[]) => void): this;
+  public override once(event: string | symbol, listener: (...args: any[]) => void): this {
+    return super.once(event, listener);
+  }
+
+  public override off(
+    event: 'update',
+    listener: (snapshot: OrderSnapshot, diff: DomainUpdate<OrderSnapshot>, reason?: string) => void,
+  ): this;
+  public override off(event: string | symbol, listener: (...args: any[]) => void): this;
+  public override off(event: string | symbol, listener: (...args: any[]) => void): this {
+    return super.off(event, listener);
+  }
+}
+
+function normalizeId(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function normalizeSymbol(value: unknown): Symbol {
+  if (typeof value !== 'string') {
+    return '' as Symbol;
+  }
+
+  return value.trim() as Symbol;
+}
+
+function normalizeSide(value: unknown): Side | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  if (normalized === 'buy' || normalized === 'sell') {
+    return normalized as Side;
+  }
+
+  return null;
+}
+
+function normalizeString(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function normalizeOptionalNumber(value: unknown): number | null {
+  if (typeof value !== 'number') {
+    return null;
+  }
+
+  if (!Number.isFinite(value)) {
+    return null;
+  }
+
+  return value;
+}
+
+function normalizeQuantity(value: unknown): number | null {
+  if (typeof value !== 'number') {
+    return null;
+  }
+
+  if (!Number.isFinite(value)) {
+    return null;
+  }
+
+  if (value <= 0) {
+    return value === 0 ? 0 : null;
+  }
+
+  return value;
+}
+
+function normalizeTimestamp(value: unknown): number | null {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : null;
+  }
+
+  if (typeof value === 'string') {
+    const ts = Date.parse(value);
+    return Number.isFinite(ts) ? ts : null;
+  }
+
+  return null;
+}

--- a/tests/integration/private/order-stream.test.ts
+++ b/tests/integration/private/order-stream.test.ts
@@ -1,0 +1,229 @@
+import { ExchangeHub } from '../../../src/ExchangeHub.js';
+import { handleOrderMessage } from '../../../src/core/bitmex/channels/order.js';
+import { OrderStatus } from '../../../src/domain/order.js';
+
+import type { BitMex } from '../../../src/core/bitmex/index.js';
+import type { BitMexOrder } from '../../../src/core/bitmex/types.js';
+import type { Settings } from '../../../src/types.js';
+
+class FakeWebSocket {
+  public readonly url: string;
+  public onmessage: ((event: { data: unknown }) => void) | null = null;
+  #listeners = new Map<string, Set<(...args: unknown[]) => void>>();
+
+  constructor(url: string) {
+    this.url = url;
+  }
+
+  addEventListener(event: string, listener: (...args: unknown[]) => void): void {
+    if (!this.#listeners.has(event)) {
+      this.#listeners.set(event, new Set());
+    }
+
+    this.#listeners.get(event)!.add(listener);
+  }
+
+  removeEventListener(event: string, listener: (...args: unknown[]) => void): void {
+    this.#listeners.get(event)?.delete(listener);
+  }
+
+  send(_data: string): void {}
+
+  close(): void {
+    this.#emit('close');
+  }
+
+  simulateOpen(): void {
+    this.#emit('open');
+  }
+
+  simulateMessage(data: unknown): void {
+    this.onmessage?.({ data });
+    this.#emit('message', { data });
+  }
+
+  #emit(event: string, ...args: unknown[]): void {
+    const handler = (this as any)[`on${event}`];
+    if (typeof handler === 'function') {
+      handler(...args);
+    }
+
+    for (const listener of this.#listeners.get(event) ?? []) {
+      listener(...args);
+    }
+  }
+}
+
+const ORIGINAL_WEBSOCKET = (globalThis as any).WebSocket;
+
+beforeAll(() => {
+  (globalThis as any).WebSocket = FakeWebSocket;
+});
+
+afterAll(() => {
+  (globalThis as any).WebSocket = ORIGINAL_WEBSOCKET;
+});
+
+function createHub(settings: Partial<Settings> = {}) {
+  const hub = new ExchangeHub('BitMex', { isTest: true, ...settings });
+  const core = hub.Core as BitMex;
+
+  return { hub, core };
+}
+
+describe('BitMEX private order stream', () => {
+  test('handles lifecycle, fills, and resynchronization', () => {
+    const { hub, core } = createHub();
+    const store = hub.orders;
+
+    const partial: BitMexOrder[] = [
+      {
+        orderID: 'ord-1',
+        clOrdID: 'cli-1',
+        symbol: 'XBTUSD',
+        side: 'Buy',
+        orderQty: 100,
+        price: 50_000,
+        leavesQty: 100,
+        cumQty: 0,
+        avgPx: 0,
+        ordStatus: 'New',
+        execType: 'New',
+        timestamp: '2024-01-01T00:00:00.000Z',
+      },
+      {
+        orderID: 'ord-2',
+        clOrdID: 'cli-2',
+        symbol: 'XBTUSD',
+        side: 'Sell',
+        orderQty: 50,
+        price: 50_100,
+        leavesQty: 50,
+        cumQty: 0,
+        avgPx: 0,
+        ordStatus: 'New',
+        execType: 'New',
+        timestamp: '2024-01-01T00:00:05.000Z',
+      },
+    ];
+
+    handleOrderMessage(core, { table: 'order', action: 'partial', data: partial });
+
+    expect(store.getByOrderId('ord-1')).toBeDefined();
+    expect(store.getByOrderId('ord-2')).toBeDefined();
+    expect(store.getActiveBySymbol('XBTUSD')).toHaveLength(2);
+
+    const firstFill: BitMexOrder[] = [
+      {
+        orderID: 'ord-1',
+        symbol: 'XBTUSD',
+        side: 'Buy',
+        orderQty: 100,
+        leavesQty: 60,
+        cumQty: 40,
+        avgPx: 50_010,
+        execID: 'exec-1',
+        execType: 'Trade',
+        ordStatus: 'PartiallyFilled',
+        lastQty: 40,
+        lastPx: 50_010,
+        lastLiquidityInd: 'AddedLiquidity',
+        transactTime: '2024-01-01T00:00:10.000Z',
+      },
+    ];
+
+    handleOrderMessage(core, { table: 'order', action: 'update', data: firstFill });
+
+    const order1 = store.getByOrderId('ord-1');
+    expect(order1).toBeDefined();
+    let snapshot1 = order1!.getSnapshot();
+    expect(snapshot1.status).toBe(OrderStatus.PartiallyFilled);
+    expect(snapshot1.filledQty).toBe(40);
+    expect(snapshot1.avgFillPrice).toBeCloseTo(50_010, 6);
+    expect(snapshot1.executions).toHaveLength(1);
+    expect(snapshot1.executions[0]?.execId).toBe('exec-1');
+    expect(snapshot1.executions[0]?.liquidity).toBe('maker');
+
+    const cancel: BitMexOrder[] = [
+      {
+        orderID: 'ord-2',
+        symbol: 'XBTUSD',
+        leavesQty: 0,
+        cumQty: 0,
+        avgPx: 0,
+        ordStatus: 'Canceled',
+        execType: 'Canceled',
+        timestamp: '2024-01-01T00:00:12.000Z',
+      },
+    ];
+
+    handleOrderMessage(core, { table: 'order', action: 'update', data: cancel });
+
+    const order2 = store.getByOrderId('ord-2');
+    expect(order2).toBeDefined();
+    const snapshot2 = order2!.getSnapshot();
+    expect(snapshot2.status).toBe(OrderStatus.Canceled);
+    expect(store.getActiveBySymbol('XBTUSD')).toHaveLength(1);
+
+    const finalFill: BitMexOrder[] = [
+      {
+        orderID: 'ord-1',
+        symbol: 'XBTUSD',
+        leavesQty: 0,
+        cumQty: 100,
+        avgPx: 50_020,
+        execID: 'exec-2',
+        execType: 'Trade',
+        ordStatus: 'Filled',
+        lastQty: 60,
+        lastPx: 50_030,
+        lastLiquidityInd: 'RemovedLiquidity',
+        transactTime: '2024-01-01T00:00:20.000Z',
+      },
+    ];
+
+    handleOrderMessage(core, { table: 'order', action: 'update', data: finalFill });
+
+    snapshot1 = order1!.getSnapshot();
+    expect(snapshot1.status).toBe(OrderStatus.Filled);
+    expect(snapshot1.filledQty).toBe(100);
+    expect(snapshot1.avgFillPrice).toBeCloseTo(50_020, 6);
+    expect(snapshot1.executions).toHaveLength(2);
+    expect(store.getActiveOrders()).toHaveLength(0);
+
+    // duplicate update should be ignored by execId dedupe
+    handleOrderMessage(core, { table: 'order', action: 'update', data: finalFill });
+    const afterDuplicate = order1!.getSnapshot();
+    expect(afterDuplicate.filledQty).toBe(100);
+    expect(afterDuplicate.executions).toHaveLength(2);
+
+    const resync: BitMexOrder[] = [
+      {
+        orderID: 'ord-1',
+        clOrdID: 'cli-1',
+        symbol: 'XBTUSD',
+        orderQty: 100,
+        leavesQty: 0,
+        cumQty: 100,
+        avgPx: 50_020,
+        ordStatus: 'Filled',
+        execType: 'Trade',
+        timestamp: '2024-01-01T00:01:00.000Z',
+      },
+    ];
+
+    handleOrderMessage(core, { table: 'order', action: 'partial', data: resync });
+
+    const resynced = order1!.getSnapshot();
+    expect(resynced.status).toBe(OrderStatus.Filled);
+    expect(resynced.filledQty).toBe(100);
+    expect(resynced.avgFillPrice).toBeCloseTo(50_020, 6);
+    expect(resynced.executions).toHaveLength(2);
+
+    expect(store.getByClOrdId('cli-1')).toBe(order1);
+    expect(store.getBySymbol('XBTUSD').map((order) => order.orderId).sort()).toEqual([
+      'ord-1',
+      'ord-2',
+    ]);
+  });
+});

--- a/tests/unit/domain/order-fills.test.ts
+++ b/tests/unit/domain/order-fills.test.ts
@@ -1,0 +1,99 @@
+import { Order, OrderStatus } from '../../../src/domain/order.js';
+
+describe('Order fills', () => {
+  test('computes VWAP across executions', () => {
+    const order = new Order({ orderId: 'ord-1', symbol: 'XBTUSD', status: OrderStatus.Placed, qty: 100 });
+
+    order.applyUpdate(
+      {
+        execution: { execId: 'exec-1', qty: 20, price: 100, ts: 1 },
+        cumQty: 20,
+        avgPx: 100,
+        leavesQty: 80,
+        status: OrderStatus.PartiallyFilled,
+      },
+      { reason: 'fill' },
+    );
+
+    let snapshot = order.getSnapshot();
+    expect(snapshot.filledQty).toBe(20);
+    expect(snapshot.avgFillPrice).toBe(100);
+    expect(snapshot.executions).toHaveLength(1);
+    expect(snapshot.executions[0]?.execId).toBe('exec-1');
+
+    order.applyUpdate(
+      {
+        execution: { execId: 'exec-2', qty: 30, price: 110, ts: 2 },
+        cumQty: 50,
+        avgPx: 106,
+        leavesQty: 50,
+        status: OrderStatus.PartiallyFilled,
+      },
+      { reason: 'fill' },
+    );
+
+    snapshot = order.getSnapshot();
+    expect(snapshot.filledQty).toBe(50);
+    expect(snapshot.avgFillPrice).toBeCloseTo(106, 10);
+    expect(snapshot.executions).toHaveLength(2);
+  });
+
+  test('ignores duplicate executions with the same execId', () => {
+    const order = new Order({ orderId: 'ord-dup', symbol: 'XBTUSD', status: OrderStatus.Placed, qty: 10 });
+
+    order.applyUpdate(
+      {
+        execution: { execId: 'exec-dup', qty: 5, price: 200, ts: 1 },
+        cumQty: 5,
+        avgPx: 200,
+        leavesQty: 5,
+        status: OrderStatus.PartiallyFilled,
+      },
+      { reason: 'fill' },
+    );
+
+    const snapshot = order.getSnapshot();
+    expect(snapshot.filledQty).toBe(5);
+    expect(snapshot.executions).toHaveLength(1);
+
+    order.applyUpdate(
+      {
+        execution: { execId: 'exec-dup', qty: 5, price: 210, ts: 2 },
+        cumQty: 5,
+        avgPx: 200,
+        leavesQty: 5,
+        status: OrderStatus.PartiallyFilled,
+      },
+      { reason: 'fill' },
+    );
+
+    const afterDuplicate = order.getSnapshot();
+    expect(afterDuplicate.filledQty).toBe(5);
+    expect(afterDuplicate.executions).toHaveLength(1);
+    expect(afterDuplicate.avgFillPrice).toBe(200);
+  });
+
+  test('execution updates override local canceling state', () => {
+    const order = new Order({ orderId: 'ord-cancel', symbol: 'XBTUSD', status: OrderStatus.Placed, qty: 10 });
+
+    order.markCanceling();
+    expect(order.getSnapshot().status).toBe(OrderStatus.Canceling);
+
+    order.applyUpdate(
+      {
+        execution: { execId: 'exec-final', qty: 10, price: 105, ts: 3 },
+        cumQty: 10,
+        avgPx: 105,
+        leavesQty: 0,
+        status: OrderStatus.Filled,
+      },
+      { reason: 'fill' },
+    );
+
+    const snapshot = order.getSnapshot();
+    expect(snapshot.status).toBe(OrderStatus.Filled);
+    expect(snapshot.filledQty).toBe(10);
+    expect(snapshot.avgFillPrice).toBe(105);
+    expect(snapshot.executions).toHaveLength(1);
+  });
+});

--- a/tests/unit/mappers/order-mapping.test.ts
+++ b/tests/unit/mappers/order-mapping.test.ts
@@ -1,27 +1,120 @@
 import { mapBitmexOrderStatus } from '../../../src/core/bitmex/mappers/order.js';
 import { OrderStatus } from '../../../src/domain/order.js';
 
+import type { BitMexExecType, BitMexOrderStatus } from '../../../src/core/bitmex/types.js';
+
 describe('BitMEX order status mapping', () => {
-  test.each([
-    { ordStatus: 'New', execType: undefined, expected: OrderStatus.Placed },
-    { ordStatus: 'PartiallyFilled', execType: undefined, expected: OrderStatus.PartiallyFilled },
-    { ordStatus: 'Filled', execType: undefined, expected: OrderStatus.Filled },
-    { ordStatus: 'Canceled', execType: undefined, expected: OrderStatus.Canceled },
-    { ordStatus: 'Rejected', execType: undefined, expected: OrderStatus.Rejected },
-    { ordStatus: 'Expired', execType: undefined, expected: OrderStatus.Expired },
-    { ordStatus: 'Triggered', execType: undefined, expected: OrderStatus.Placed },
-    { ordStatus: 'Filled', execType: 'Trade', expected: OrderStatus.Filled },
-    { ordStatus: 'PartiallyFilled', execType: 'Trade', expected: OrderStatus.PartiallyFilled },
-    { ordStatus: 'Canceled', execType: 'Trade', expected: OrderStatus.Canceled },
-    { ordStatus: undefined, execType: 'Trade', expected: OrderStatus.PartiallyFilled },
-    { ordStatus: undefined, execType: 'Canceled', expected: OrderStatus.Canceled },
-    { ordStatus: undefined, execType: 'Expired', expected: OrderStatus.Expired },
-    { ordStatus: undefined, execType: 'New', expected: OrderStatus.Placed },
-  ])('maps ordStatus=%s execType=%s to %s', ({ ordStatus, execType, expected }) => {
-    expect(mapBitmexOrderStatus(ordStatus as any, execType as any)).toBe(expected);
+  type MappingCase = {
+    title: string;
+    input: {
+      ordStatus?: BitMexOrderStatus | undefined;
+      execType?: BitMexExecType | undefined;
+      leavesQty?: number;
+      cumQty?: number;
+    };
+    expected: OrderStatus;
+  };
+
+  const baseCases: MappingCase[] = [
+    {
+      title: 'acknowledges new order',
+      input: { ordStatus: 'New', execType: 'New', leavesQty: 100, cumQty: 0 },
+      expected: OrderStatus.Placed,
+    },
+    {
+      title: 'partial fill from trade leaves open quantity',
+      input: { ordStatus: 'PartiallyFilled', execType: 'Trade', leavesQty: 10, cumQty: 5 },
+      expected: OrderStatus.PartiallyFilled,
+    },
+    {
+      title: 'trade with zero leaves marks as filled',
+      input: { ordStatus: 'Filled', execType: 'Trade', leavesQty: 0, cumQty: 10 },
+      expected: OrderStatus.Filled,
+    },
+    {
+      title: 'explicit cancel',
+      input: { ordStatus: 'Canceled', execType: 'Canceled', leavesQty: 0, cumQty: 0 },
+      expected: OrderStatus.Canceled,
+    },
+    {
+      title: 'rejection stays rejected',
+      input: { ordStatus: 'Rejected', execType: 'New', leavesQty: 0, cumQty: 0 },
+      expected: OrderStatus.Rejected,
+    },
+    {
+      title: 'expiry event',
+      input: { ordStatus: 'Expired', execType: 'Expired', leavesQty: 0, cumQty: 0 },
+      expected: OrderStatus.Expired,
+    },
+    {
+      title: 'triggered stop treated as placed',
+      input: { ordStatus: 'Triggered', execType: 'New', leavesQty: 50, cumQty: 0 },
+      expected: OrderStatus.Placed,
+    },
+    {
+      title: 'trade without ordStatus uses quantities',
+      input: { ordStatus: undefined, execType: 'Trade', leavesQty: 5, cumQty: 2 },
+      expected: OrderStatus.PartiallyFilled,
+    },
+    {
+      title: 'trade overrides cancel to filled when leaves zero',
+      input: { ordStatus: 'Canceled', execType: 'Trade', leavesQty: 0, cumQty: 8 },
+      expected: OrderStatus.Filled,
+    },
+  ] as const;
+
+  test.each(baseCases)('%s', ({ input, expected }) => {
+    expect(
+      mapBitmexOrderStatus({
+        ...input,
+        previousStatus: null,
+      }),
+    ).toBe(expected);
   });
 
-  test('returns undefined when both ordStatus and execType are missing', () => {
-    expect(mapBitmexOrderStatus(undefined, undefined)).toBeUndefined();
+  test('returns previous status when no signals provided', () => {
+    expect(
+      mapBitmexOrderStatus({
+        ordStatus: undefined,
+        execType: undefined,
+        previousStatus: OrderStatus.PartiallyFilled,
+      }),
+    ).toBe(OrderStatus.PartiallyFilled);
+  });
+
+  test('does not downgrade filled to placed', () => {
+    expect(
+      mapBitmexOrderStatus({
+        ordStatus: 'New',
+        execType: 'New',
+        leavesQty: 20,
+        cumQty: 0,
+        previousStatus: OrderStatus.Filled,
+      }),
+    ).toBe(OrderStatus.Filled);
+  });
+
+  test('does not downgrade canceled to placed', () => {
+    expect(
+      mapBitmexOrderStatus({
+        ordStatus: 'New',
+        execType: 'New',
+        leavesQty: 50,
+        cumQty: 0,
+        previousStatus: OrderStatus.Canceled,
+      }),
+    ).toBe(OrderStatus.Canceled);
+  });
+
+  test('upgrades canceled to filled when trade indicates completion', () => {
+    expect(
+      mapBitmexOrderStatus({
+        ordStatus: 'Canceled',
+        execType: 'Trade',
+        leavesQty: 0,
+        cumQty: 10,
+        previousStatus: OrderStatus.Canceled,
+      }),
+    ).toBe(OrderStatus.Filled);
   });
 });

--- a/tests/unit/mappers/order-mapping.test.ts
+++ b/tests/unit/mappers/order-mapping.test.ts
@@ -1,0 +1,27 @@
+import { mapBitmexOrderStatus } from '../../../src/core/bitmex/mappers/order.js';
+import { OrderStatus } from '../../../src/domain/order.js';
+
+describe('BitMEX order status mapping', () => {
+  test.each([
+    { ordStatus: 'New', execType: undefined, expected: OrderStatus.Placed },
+    { ordStatus: 'PartiallyFilled', execType: undefined, expected: OrderStatus.PartiallyFilled },
+    { ordStatus: 'Filled', execType: undefined, expected: OrderStatus.Filled },
+    { ordStatus: 'Canceled', execType: undefined, expected: OrderStatus.Canceled },
+    { ordStatus: 'Rejected', execType: undefined, expected: OrderStatus.Rejected },
+    { ordStatus: 'Expired', execType: undefined, expected: OrderStatus.Expired },
+    { ordStatus: 'Triggered', execType: undefined, expected: OrderStatus.Placed },
+    { ordStatus: 'Filled', execType: 'Trade', expected: OrderStatus.Filled },
+    { ordStatus: 'PartiallyFilled', execType: 'Trade', expected: OrderStatus.PartiallyFilled },
+    { ordStatus: 'Canceled', execType: 'Trade', expected: OrderStatus.Canceled },
+    { ordStatus: undefined, execType: 'Trade', expected: OrderStatus.PartiallyFilled },
+    { ordStatus: undefined, execType: 'Canceled', expected: OrderStatus.Canceled },
+    { ordStatus: undefined, execType: 'Expired', expected: OrderStatus.Expired },
+    { ordStatus: undefined, execType: 'New', expected: OrderStatus.Placed },
+  ])('maps ordStatus=%s execType=%s to %s', ({ ordStatus, execType, expected }) => {
+    expect(mapBitmexOrderStatus(ordStatus as any, execType as any)).toBe(expected);
+  });
+
+  test('returns undefined when both ordStatus and execType are missing', () => {
+    expect(mapBitmexOrderStatus(undefined, undefined)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- add a domain Order entity that tracks VWAP, fills, and emits typed update events
- introduce an orders registry on the hub with lookups by id, symbol, and active status
- implement BitMEX order channel processing with status mapping, execution dedupe, and new unit/integration tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd1e5c5a308320aa808a29ba15e5a7