### PR TITLE
feat(core): Instrument.buy/sell + order auto-type + clOrdID

### DIFF
--- a/src/domain/order.ts
+++ b/src/domain/order.ts
@@ -53,6 +53,7 @@ export type OrderSnapshot = {
   avgFillPrice: number | null;
   text: string | null;
   lastUpdateTs: number | null;
+  submittedAt: number | null;
   executions: Execution[];
 };
 
@@ -104,6 +105,7 @@ export class Order extends EventEmitter implements BaseEntity<OrderSnapshot> {
   #leavesQty: number | null = null;
   #text: string | null = null;
   #lastUpdateTs: number | null = null;
+  #submittedAt: number | null = null;
 
   #filledQty = 0;
   #avgFillPrice: number | null = null;
@@ -129,6 +131,7 @@ export class Order extends EventEmitter implements BaseEntity<OrderSnapshot> {
       leavesQty,
       text,
       lastUpdateTs,
+      submittedAt,
       filledQty,
       avgFillPrice,
     } = init;
@@ -151,6 +154,7 @@ export class Order extends EventEmitter implements BaseEntity<OrderSnapshot> {
     this.#leavesQty = normalizeOptionalNumber(leavesQty);
     this.#text = normalizeString(text);
     this.#lastUpdateTs = normalizeTimestamp(lastUpdateTs);
+    this.#submittedAt = normalizeTimestamp(submittedAt);
 
     const initialFilled = normalizeQuantity(filledQty);
     if (initialFilled !== null) {
@@ -205,6 +209,7 @@ export class Order extends EventEmitter implements BaseEntity<OrderSnapshot> {
       avgFillPrice: this.#avgFillPrice,
       text: this.#text,
       lastUpdateTs: this.#lastUpdateTs,
+      submittedAt: this.#submittedAt,
       executions: this.#executions.map((execution) => ({ ...execution })),
     };
   }
@@ -310,6 +315,14 @@ export class Order extends EventEmitter implements BaseEntity<OrderSnapshot> {
       if (!Object.is(this.#lastUpdateTs, next)) {
         this.#lastUpdateTs = next;
         changed.add('lastUpdateTs');
+      }
+    }
+
+    if ('submittedAt' in update) {
+      const next = normalizeTimestamp(update.submittedAt);
+      if (!Object.is(this.#submittedAt, next)) {
+        this.#submittedAt = next;
+        changed.add('submittedAt');
       }
     }
 

--- a/src/infra/ids.ts
+++ b/src/infra/ids.ts
@@ -1,0 +1,44 @@
+import { randomBytes } from 'node:crypto';
+
+const DEFAULT_PREFIX = 'eh';
+const PREFIX_SANITIZE_REGEX = /[^a-zA-Z0-9]+/g;
+const COUNTER_MAX = 36 ** 4;
+const counters = new Map<string, number>();
+
+function sanitizeSeed(seed?: string): string {
+  if (typeof seed !== 'string') {
+    return DEFAULT_PREFIX;
+  }
+
+  const trimmed = seed.trim();
+  if (!trimmed) {
+    return DEFAULT_PREFIX;
+  }
+
+  const normalized = trimmed.replace(PREFIX_SANITIZE_REGEX, '').toLowerCase();
+  return normalized || DEFAULT_PREFIX;
+}
+
+function nextCounter(prefix: string): number {
+  const current = counters.get(prefix) ?? 0;
+  const next = (current + 1) % COUNTER_MAX;
+  counters.set(prefix, next);
+  return next;
+}
+
+function formatCounter(counter: number): string {
+  return counter.toString(36).padStart(4, '0');
+}
+
+function randomSuffix(): string {
+  return randomBytes(2).toString('hex');
+}
+
+export function genClOrdID(seed?: string): string {
+  const prefix = sanitizeSeed(seed);
+  const counter = nextCounter(prefix);
+  const timestamp = Date.now().toString(36);
+  const suffix = randomSuffix();
+
+  return `${prefix}-${timestamp}-${formatCounter(counter)}${suffix}`;
+}

--- a/src/infra/validation.ts
+++ b/src/infra/validation.ts
@@ -1,0 +1,154 @@
+import { ValidationError } from './errors.js';
+
+import type { ClOrdID, Symbol } from '../core/types.js';
+import type { Side } from '../types.js';
+
+export type OrderType = 'Market' | 'Limit' | 'Stop';
+
+export interface PlaceOpts {
+  postOnly?: boolean;
+  clOrdID?: ClOrdID;
+  timeInForce?: string;
+  reduceOnly?: boolean;
+}
+
+export interface PlaceValidationParams {
+  symbol: Symbol;
+  side: Side;
+  size: number;
+  price?: number;
+  type: OrderType;
+  opts?: PlaceOpts;
+}
+
+export interface NormalizedPlaceOptions {
+  postOnly: boolean;
+  reduceOnly: boolean;
+  timeInForce: string | null;
+  clOrdId?: ClOrdID;
+}
+
+export interface NormalizedPlaceInput {
+  symbol: Symbol;
+  side: Side;
+  size: number;
+  type: OrderType;
+  price: number | null;
+  stopPrice: number | null;
+  options: NormalizedPlaceOptions;
+}
+
+export type PreparedPlaceInput = NormalizedPlaceInput & {
+  options: NormalizedPlaceOptions & { clOrdId: ClOrdID };
+};
+
+function normalizeSymbol(symbol: Symbol): Symbol {
+  if (typeof symbol !== 'string') {
+    throw new ValidationError('Instrument symbol must be a string');
+  }
+
+  const trimmed = symbol.trim();
+  if (!trimmed) {
+    throw new ValidationError('Instrument symbol cannot be empty');
+  }
+
+  return trimmed as Symbol;
+}
+
+function normalizeSize(size: number): number {
+  if (typeof size !== 'number' || Number.isNaN(size)) {
+    throw new ValidationError('Order size must be a number', { details: { size } });
+  }
+
+  if (!Number.isFinite(size)) {
+    throw new ValidationError('Order size must be finite', { details: { size } });
+  }
+
+  if (size <= 0) {
+    throw new ValidationError('Order size must be greater than zero', { details: { size } });
+  }
+
+  return size;
+}
+
+function normalizePrice(price: number | undefined): number | null {
+  if (price === undefined || price === null) {
+    return null;
+  }
+
+  if (typeof price !== 'number' || !Number.isFinite(price)) {
+    throw new ValidationError('Price must be a finite number', { details: { price } });
+  }
+
+  return price;
+}
+
+function normalizeTimeInForce(timeInForce: string | undefined): string | null {
+  if (typeof timeInForce !== 'string') {
+    return null;
+  }
+
+  const trimmed = timeInForce.trim();
+  return trimmed ? trimmed : null;
+}
+
+function normalizeClOrdId(clOrdID: ClOrdID | undefined): ClOrdID | undefined {
+  if (typeof clOrdID !== 'string') {
+    return undefined;
+  }
+
+  const trimmed = clOrdID.trim();
+  if (!trimmed) {
+    throw new ValidationError('clOrdID cannot be empty');
+  }
+
+  return trimmed as ClOrdID;
+}
+
+export function validatePlaceInput(params: PlaceValidationParams): NormalizedPlaceInput {
+  const { symbol, side, size, price, type, opts } = params;
+
+  if (side !== 'buy' && side !== 'sell') {
+    throw new ValidationError('Order side must be "buy" or "sell"', { details: { side } });
+  }
+
+  const normalizedSymbol = normalizeSymbol(symbol);
+  const normalizedSize = normalizeSize(size);
+  const normalizedPrice = normalizePrice(price);
+
+  if (type === 'Market') {
+    if (normalizedPrice !== null) {
+      throw new ValidationError('Market orders cannot have a price', { details: { price } });
+    }
+  } else {
+    if (normalizedPrice === null) {
+      throw new ValidationError(`${type} orders require a price`, { details: { price } });
+    }
+  }
+
+  const postOnly = Boolean(opts?.postOnly);
+  if (postOnly && type !== 'Limit') {
+    throw new ValidationError('postOnly flag is allowed only for limit orders', {
+      details: { type, postOnly },
+    });
+  }
+
+  const reduceOnly = Boolean(opts?.reduceOnly);
+  const timeInForce = normalizeTimeInForce(opts?.timeInForce);
+  const clOrdId = normalizeClOrdId(opts?.clOrdID);
+
+  return {
+    symbol: normalizedSymbol,
+    side,
+    size: normalizedSize,
+    type,
+    price: type === 'Limit' ? normalizedPrice : null,
+    stopPrice: type === 'Stop' ? normalizedPrice : null,
+    options: {
+      postOnly,
+      reduceOnly,
+      timeInForce,
+      ...(clOrdId ? { clOrdId } : {}),
+    },
+  };
+}

--- a/tests/unit/core/ids/clordid.spec.ts
+++ b/tests/unit/core/ids/clordid.spec.ts
@@ -1,0 +1,77 @@
+import { genClOrdID } from '../../../../src/infra/ids.js';
+import { Instrument } from '../../../../src/domain/instrument.js';
+
+let seedCounter = 0;
+function uniqueSeed(): string {
+  seedCounter += 1;
+  return `unit-seed-${seedCounter}`;
+}
+
+function extractCounter(id: string): number {
+  const lastSegment = id.split('-').pop() ?? '';
+  const counterPart = lastSegment.slice(0, 4);
+  return parseInt(counterPart, 36);
+}
+
+describe('genClOrdID', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('produces sequential identifiers for the same seed', () => {
+    jest.spyOn(Date, 'now').mockReturnValue(1_700_000_000_000);
+    const seed = uniqueSeed();
+
+    const first = genClOrdID(seed);
+    const second = genClOrdID(seed);
+    const third = genClOrdID(seed);
+
+    expect(first).not.toBe(second);
+    expect(second).not.toBe(third);
+    expect(extractCounter(second)).toBe(extractCounter(first) + 1);
+    expect(extractCounter(third)).toBe(extractCounter(second) + 1);
+  });
+
+  test('normalizes provided seed', () => {
+    jest.spyOn(Date, 'now').mockReturnValue(1_700_000_000_100);
+    const generated = genClOrdID('  My Bot 01  ');
+    expect(generated.startsWith('mybot01-')).toBe(true);
+
+    const fallback = genClOrdID('   ');
+    expect(fallback.startsWith('eh-')).toBe(true);
+  });
+});
+
+describe('Instrument clOrdID handling', () => {
+  function createInstrument(): Instrument {
+    return new Instrument(
+      { symbolNative: 'XBTUSD', symbolUni: 'btcusdt' },
+      { tradeBufferSize: 10 },
+    );
+  }
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('preserves user-supplied clOrdID', () => {
+    const instrument = createInstrument();
+    instrument.orderBook.bestBid = { price: 100, size: 10 };
+    instrument.orderBook.bestAsk = { price: 101, size: 10 };
+
+    const result = instrument.buy(5, 100, { clOrdID: '  client-42  ' });
+
+    expect(result.options.clOrdId).toBe('client-42');
+    expect(result.type).toBe('Limit');
+  });
+
+  test('generates clOrdID when not provided', () => {
+    jest.spyOn(Date, 'now').mockReturnValue(1_700_000_000_200);
+    const instrument = createInstrument();
+
+    const result = instrument.sell(2);
+
+    expect(result.options.clOrdId).toMatch(/^eh-/);
+    expect(result.type).toBe('Market');
+  });
+});

--- a/tests/unit/core/mappers/order-type.spec.ts
+++ b/tests/unit/core/mappers/order-type.spec.ts
@@ -1,0 +1,33 @@
+import { inferOrderType } from '../../../../src/core/bitmex/mappers/order.js';
+
+describe('inferOrderType', () => {
+  test('returns Market when price is omitted', () => {
+    expect(inferOrderType('buy', undefined, 100, 105)).toBe('Market');
+    expect(inferOrderType('sell', null, 100, 105)).toBe('Market');
+  });
+
+  test('classifies buy limit zone at or below best ask', () => {
+    expect(inferOrderType('buy', 100, 95, 105)).toBe('Limit');
+    expect(inferOrderType('buy', 104, 95, 105)).toBe('Limit');
+  });
+
+  test('classifies buy stop zone above best ask', () => {
+    expect(inferOrderType('buy', 106, 95, 105)).toBe('Stop');
+    expect(inferOrderType('buy', 120, undefined, 110)).toBe('Stop');
+  });
+
+  test('classifies sell limit zone at or above best bid', () => {
+    expect(inferOrderType('sell', 105, 100, 110)).toBe('Limit');
+    expect(inferOrderType('sell', 101, 100, 110)).toBe('Limit');
+  });
+
+  test('classifies sell stop zone below best bid', () => {
+    expect(inferOrderType('sell', 98, 100, 110)).toBe('Stop');
+    expect(inferOrderType('sell', 50, 60, undefined)).toBe('Stop');
+  });
+
+  test('defaults to limit when no book context is available', () => {
+    expect(inferOrderType('buy', 10, undefined, undefined)).toBe('Limit');
+    expect(inferOrderType('sell', 10, undefined, undefined)).toBe('Limit');
+  });
+});

--- a/tests/unit/infra/validation/place-input.spec.ts
+++ b/tests/unit/infra/validation/place-input.spec.ts
@@ -1,0 +1,98 @@
+import { ValidationError } from '../../../../src/infra/errors.js';
+import { validatePlaceInput } from '../../../../src/infra/validation.js';
+
+describe('validatePlaceInput', () => {
+  test('normalizes a valid limit order payload', () => {
+    const result = validatePlaceInput({
+      symbol: 'XBTUSD',
+      side: 'buy',
+      size: 10,
+      price: 65_000,
+      type: 'Limit',
+      opts: {
+        postOnly: true,
+        timeInForce: '  GoodTillCancel ',
+        reduceOnly: false,
+        clOrdID: '  client-01  ',
+      },
+    });
+
+    expect(result).toMatchObject({
+      symbol: 'XBTUSD',
+      side: 'buy',
+      size: 10,
+      type: 'Limit',
+      price: 65_000,
+      stopPrice: null,
+      options: {
+        postOnly: true,
+        reduceOnly: false,
+        timeInForce: 'GoodTillCancel',
+        clOrdId: 'client-01',
+      },
+    });
+  });
+
+  test('normalizes a stop order and ignores postOnly flag', () => {
+    const result = validatePlaceInput({
+      symbol: 'XBTUSD',
+      side: 'sell',
+      size: 2,
+      price: 63_500,
+      type: 'Stop',
+      opts: { reduceOnly: true },
+    });
+
+    expect(result.price).toBeNull();
+    expect(result.stopPrice).toBe(63_500);
+    expect(result.options.postOnly).toBe(false);
+    expect(result.options.reduceOnly).toBe(true);
+  });
+
+  test('throws when market order carries price', () => {
+    expect(() =>
+      validatePlaceInput({
+        symbol: 'XBTUSD',
+        side: 'buy',
+        size: 1,
+        price: 60_000,
+        type: 'Market',
+      }),
+    ).toThrow(ValidationError);
+  });
+
+  test('throws when limit order is missing price', () => {
+    expect(() =>
+      validatePlaceInput({
+        symbol: 'XBTUSD',
+        side: 'sell',
+        size: 1,
+        type: 'Limit',
+      }),
+    ).toThrow(ValidationError);
+  });
+
+  test('throws when postOnly is used for non-limit orders', () => {
+    expect(() =>
+      validatePlaceInput({
+        symbol: 'XBTUSD',
+        side: 'sell',
+        size: 1,
+        price: 64_000,
+        type: 'Stop',
+        opts: { postOnly: true },
+      }),
+    ).toThrow(ValidationError);
+  });
+
+  test('throws when size is not positive', () => {
+    expect(() =>
+      validatePlaceInput({
+        symbol: 'XBTUSD',
+        side: 'buy',
+        size: 0,
+        type: 'Market',
+      }),
+    ).toThrow(ValidationError);
+  });
+});


### PR DESCRIPTION
## Summary
- add clOrdID generator, place input validation helper, and BitMEX order type inference
- extend Instrument with buy/sell helpers and OrdersRegistry with clOrdID inflight tracking
- capture client metadata on orders and cover new helpers with unit tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd694a274c83209d7013079428cd70