### PR TITLE
feat(bitmex): REST create order + payload mapping (market/limit/postOnly)

### DIFF
--- a/src/core/bitmex/rest/orders.ts
+++ b/src/core/bitmex/rest/orders.ts
@@ -1,0 +1,130 @@
+import { createLogger, LOG_TAGS, type Logger } from '../../../infra/logger.js';
+import { BaseError } from '../../../infra/errors.js';
+
+import { BitmexRestClient } from './request.js';
+
+import type { BitMexOrder, BitMexOrderType, BitMexTimeInForce } from '../types.js';
+
+export type CreateOrderPayload = {
+  symbol: string;
+  side: 'Buy' | 'Sell';
+  orderQty: number;
+  ordType: BitMexOrderType;
+  price?: number;
+  clOrdID?: string;
+  stopPx?: number;
+  execInst?: string;
+  timeInForce?: BitMexTimeInForce;
+};
+
+export interface CreateOrderOptions {
+  timeoutMs?: number;
+}
+
+export interface BitmexRestOrders {
+  createOrder(payload: CreateOrderPayload, opts?: CreateOrderOptions): Promise<BitMexOrder>;
+}
+
+export interface BitmexRestOrdersOptions {
+  logger?: Logger;
+  defaultTimeoutMs?: number;
+  maxRetries?: number;
+}
+
+const DEFAULT_TIMEOUT_MS = 7_000;
+const MIN_TIMEOUT_MS = 5_000;
+const MAX_TIMEOUT_MS = 10_000;
+const DEFAULT_MAX_RETRIES = 1;
+
+export function createBitmexRestOrders(
+  client: BitmexRestClient,
+  options: BitmexRestOrdersOptions = {},
+): BitmexRestOrders {
+  const baseLogger = options.logger ?? createLogger('bitmex:rest:orders');
+  const log = baseLogger.withTags([LOG_TAGS.order]);
+  const maxRetries = normalizeRetries(options.maxRetries);
+  const defaultTimeout = normalizeTimeout(options.defaultTimeoutMs);
+
+  async function createOrder(
+    payload: CreateOrderPayload,
+    opts: CreateOrderOptions = {},
+  ): Promise<BitMexOrder> {
+    const timeoutMs = normalizeTimeout(opts.timeoutMs ?? defaultTimeout);
+    const totalAttempts = 1 + maxRetries;
+
+    for (let attempt = 0; attempt < totalAttempts; attempt += 1) {
+      try {
+        log.debug('BitMEX REST create order attempt %d', attempt + 1, {
+          symbol: payload.symbol,
+          side: payload.side,
+          ordType: payload.ordType,
+          attempt: attempt + 1,
+          totalAttempts,
+        });
+
+        return await client.request<BitMexOrder>('POST', '/api/v1/order', {
+          auth: true,
+          body: payload,
+          timeoutMs,
+        });
+      } catch (error) {
+        if (!shouldRetry(error) || attempt >= totalAttempts - 1) {
+          log.error('BitMEX REST create order failed', {
+            symbol: payload.symbol,
+            side: payload.side,
+            ordType: payload.ordType,
+            attempt: attempt + 1,
+            totalAttempts,
+            error: error instanceof Error ? error.message : String(error),
+          });
+          throw error;
+        }
+
+        log.warn('BitMEX REST create order retrying after error', {
+          symbol: payload.symbol,
+          side: payload.side,
+          ordType: payload.ordType,
+          attempt: attempt + 1,
+          totalAttempts,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+
+    throw new Error('BitMEX REST create order exhausted attempts');
+  }
+
+  return { createOrder };
+}
+
+function shouldRetry(error: unknown): boolean {
+  if (!(error instanceof BaseError)) {
+    return false;
+  }
+
+  return error.category === 'NETWORK_ERROR' || error.category === 'EXCHANGE_DOWN';
+}
+
+function normalizeTimeout(candidate?: number): number {
+  if (typeof candidate !== 'number' || !Number.isFinite(candidate) || candidate <= 0) {
+    return DEFAULT_TIMEOUT_MS;
+  }
+
+  if (candidate < MIN_TIMEOUT_MS) {
+    return MIN_TIMEOUT_MS;
+  }
+
+  if (candidate > MAX_TIMEOUT_MS) {
+    return MAX_TIMEOUT_MS;
+  }
+
+  return candidate;
+}
+
+function normalizeRetries(candidate?: number): number {
+  if (typeof candidate !== 'number' || !Number.isFinite(candidate) || candidate <= 0) {
+    return DEFAULT_MAX_RETRIES;
+  }
+
+  return Math.min(DEFAULT_MAX_RETRIES, Math.trunc(candidate));
+}

--- a/src/core/exchange-hub.ts
+++ b/src/core/exchange-hub.ts
@@ -2,6 +2,21 @@ import { Order, OrderStatus, type OrderInit, type OrderUpdateReason } from '../d
 
 import type { ClOrdID, OrderID, Symbol } from './types.js';
 import type { DomainUpdate } from './types.js';
+import type { Side } from '../types.js';
+
+export type CreateOrderParamsBase = {
+  symbol: Symbol;
+  quantity: number;
+  type: 'market' | 'limit';
+  price?: number;
+  stopPrice?: number;
+  timeInForce?: 'GTC' | 'IOC' | 'FOK' | 'DAY';
+  clientOrderId?: string;
+  postOnly?: boolean;
+  reduceOnly?: boolean;
+};
+
+export type CreateOrderParams = CreateOrderParamsBase & { side: Side };
 
 type OrderListener = (
   snapshot: ReturnType<Order['getSnapshot']>,

--- a/tests/integration/rest/create-order.limit-postonly.spec.ts
+++ b/tests/integration/rest/create-order.limit-postonly.spec.ts
@@ -1,0 +1,133 @@
+import { ExchangeHub } from '../../../src/ExchangeHub.js';
+import { BitMex } from '../../../src/core/bitmex/index.js';
+import { OrderStatus } from '../../../src/domain/order.js';
+import { ValidationError } from '../../../src/infra/errors.js';
+
+describe('BitMEX REST create order – limit/postOnly', () => {
+  const ORIGINAL_WEBSOCKET = (globalThis as any).WebSocket;
+  const ORIGINAL_FETCH = global.fetch;
+
+  beforeAll(() => {
+    (globalThis as any).WebSocket = NoopWebSocket as unknown as typeof WebSocket;
+  });
+
+  afterAll(() => {
+    (globalThis as any).WebSocket = ORIGINAL_WEBSOCKET;
+  });
+
+  afterEach(() => {
+    global.fetch = ORIGINAL_FETCH;
+    jest.restoreAllMocks();
+  });
+
+  test('creates limit order with price and postOnly execInst', async () => {
+    const { hub, core } = createCore();
+    const mockFetch = jest.fn(async () =>
+      new Response(
+        JSON.stringify({
+          orderID: 'lim-1',
+          symbol: 'XBTUSD',
+          ordStatus: 'New',
+          ordType: 'Limit',
+          orderQty: 10,
+          price: 25_000,
+          execInst: 'ParticipateDoNotInitiate',
+        }),
+        { status: 200 },
+      ),
+    );
+    global.fetch = mockFetch as unknown as typeof fetch;
+
+    const response = await core.sell({
+      symbol: 'XBTUSD',
+      quantity: 10,
+      type: 'limit',
+      price: 25_000,
+      postOnly: true,
+      clientOrderId: 'limit-1',
+    });
+
+    expect(response.execInst).toBe('ParticipateDoNotInitiate');
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [, init] = mockFetch.mock.calls[0] as [unknown, any];
+    const body = JSON.parse(init.body as string);
+    expect(body).toMatchObject({
+      symbol: 'XBTUSD',
+      side: 'Sell',
+      orderQty: 10,
+      ordType: 'Limit',
+      price: 25_000,
+      execInst: 'ParticipateDoNotInitiate',
+      clOrdID: 'limit-1',
+    });
+
+    const stored = hub.orders.getByOrderId('lim-1');
+    expect(stored).toBeDefined();
+    const snapshot = stored!.getSnapshot();
+    expect(snapshot.side).toBe('sell');
+    expect(snapshot.price).toBe(25_000);
+    expect(snapshot.execInst).toBe('ParticipateDoNotInitiate');
+    expect(snapshot.status).toBe(OrderStatus.Placed);
+  });
+
+  test('maps reduceOnly and timeInForce to execInst/timeInForce', async () => {
+    const { core } = createCore();
+    const mockFetch = jest.fn(async () =>
+      new Response(
+        JSON.stringify({
+          orderID: 'lim-2',
+          symbol: 'XBTUSD',
+          ordStatus: 'New',
+          ordType: 'Limit',
+          execInst: 'ParticipateDoNotInitiate,ReduceOnly',
+          timeInForce: 'ImmediateOrCancel',
+        }),
+        { status: 200 },
+      ),
+    );
+    global.fetch = mockFetch as unknown as typeof fetch;
+
+    const response = await core.buy({
+      symbol: 'XBTUSD',
+      quantity: 5,
+      type: 'limit',
+      price: 26_000,
+      postOnly: true,
+      reduceOnly: true,
+      timeInForce: 'IOC',
+    });
+
+    expect(response.execInst).toBe('ParticipateDoNotInitiate,ReduceOnly');
+    expect(response.timeInForce).toBe('ImmediateOrCancel');
+    const [, init] = mockFetch.mock.calls[0] as [unknown, any];
+    const body = JSON.parse(init.body as string);
+    expect(body.execInst).toBe('ParticipateDoNotInitiate,ReduceOnly');
+    expect(body.timeInForce).toBe('ImmediateOrCancel');
+  });
+
+  test('throws ValidationError when limit order has no price', async () => {
+    const { core } = createCore();
+
+    await expect(core.buy({ symbol: 'XBTUSD', quantity: 1, type: 'limit' })).rejects.toBeInstanceOf(
+      ValidationError,
+    );
+  });
+});
+
+function createCore() {
+  const hub = new ExchangeHub('BitMex', { isTest: true, apiKey: 'key', apiSec: 'secret' });
+  const core = hub.Core as BitMex;
+  return { hub, core };
+}
+
+class NoopWebSocket {
+  onmessage: ((event: any) => void) | null = null;
+
+  addEventListener() {}
+
+  removeEventListener() {}
+
+  close() {}
+
+  send() {}
+}

--- a/tests/integration/rest/create-order.market.spec.ts
+++ b/tests/integration/rest/create-order.market.spec.ts
@@ -1,0 +1,133 @@
+import { ExchangeHub } from '../../../src/ExchangeHub.js';
+import { BitMex } from '../../../src/core/bitmex/index.js';
+import { OrderStatus } from '../../../src/domain/order.js';
+import { RateLimitError, ValidationError } from '../../../src/infra/errors.js';
+
+describe('BitMEX REST create order – market', () => {
+  const ORIGINAL_WEBSOCKET = (globalThis as any).WebSocket;
+  const ORIGINAL_FETCH = global.fetch;
+
+  beforeAll(() => {
+    (globalThis as any).WebSocket = NoopWebSocket as unknown as typeof WebSocket;
+  });
+
+  afterAll(() => {
+    (globalThis as any).WebSocket = ORIGINAL_WEBSOCKET;
+  });
+
+  afterEach(() => {
+    global.fetch = ORIGINAL_FETCH;
+    jest.restoreAllMocks();
+  });
+
+  test('creates market order with correct payload', async () => {
+    const { hub, core } = createCore();
+    const mockFetch = jest.fn(async (input: unknown) => {
+      expect(String(input)).toBe('https://testnet.bitmex.com/api/v1/order');
+      return new Response(
+        JSON.stringify({
+          orderID: 'mkt-1',
+          symbol: 'XBTUSD',
+          ordStatus: 'New',
+          orderQty: 50,
+          side: 'Buy',
+        }),
+        { status: 200 },
+      );
+    });
+    global.fetch = mockFetch as unknown as typeof fetch;
+
+    const response = await core.buy({
+      symbol: 'XBTUSD',
+      quantity: 50,
+      type: 'market',
+      clientOrderId: 'client-1',
+    });
+
+    expect(response.orderID).toBe('mkt-1');
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [, init] = mockFetch.mock.calls[0] as [unknown, any];
+    expect(init.method).toBe('POST');
+    const body = JSON.parse(init.body as string);
+    expect(body).toMatchObject({
+      symbol: 'XBTUSD',
+      side: 'Buy',
+      orderQty: 50,
+      ordType: 'Market',
+      clOrdID: 'client-1',
+    });
+    expect(body).not.toHaveProperty('price');
+
+    const storedById = hub.orders.getByOrderId('mkt-1');
+    expect(storedById).toBeDefined();
+    const snapshot = storedById!.getSnapshot();
+    expect(snapshot.symbol).toBe('XBTUSD');
+    expect(snapshot.side).toBe('buy');
+    expect(snapshot.status).toBe(OrderStatus.Placed);
+    expect(snapshot.clOrdId).toBe('client-1');
+  });
+
+  test('retries once on exchange error and succeeds', async () => {
+    const { core } = createCore();
+    const responses = [
+      new Response('Server error', { status: 503 }),
+      new Response(JSON.stringify({ orderID: 'mkt-2', symbol: 'XBTUSD', ordStatus: 'New' }), {
+        status: 200,
+      }),
+    ];
+    const mockFetch = jest.fn(async () => responses.shift()!);
+    global.fetch = mockFetch as unknown as typeof fetch;
+
+    const response = await core.sell({ symbol: 'XBTUSD', quantity: 1, type: 'market' });
+
+    expect(response.orderID).toBe('mkt-2');
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  test('does not retry on 429', async () => {
+    const { core } = createCore();
+    const mockFetch = jest.fn(
+      async () =>
+        new Response(JSON.stringify({ error: { message: 'Too many' } }), {
+          status: 429,
+          headers: { 'Retry-After': '5' },
+        }),
+    );
+    global.fetch = mockFetch as unknown as typeof fetch;
+
+    await expect(core.buy({ symbol: 'XBTUSD', quantity: 1, type: 'market' })).rejects.toBeInstanceOf(
+      RateLimitError,
+    );
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  test('throws ValidationError for invalid combinations', async () => {
+    const { core } = createCore();
+
+    await expect(
+      core.buy({ symbol: 'XBTUSD', quantity: 1, type: 'market', postOnly: true }),
+    ).rejects.toBeInstanceOf(ValidationError);
+
+    await expect(core.sell({ symbol: 'XBTUSD', quantity: 0, type: 'market' })).rejects.toBeInstanceOf(
+      ValidationError,
+    );
+  });
+});
+
+function createCore() {
+  const hub = new ExchangeHub('BitMex', { isTest: true, apiKey: 'key', apiSec: 'secret' });
+  const core = hub.Core as BitMex;
+  return { hub, core };
+}
+
+class NoopWebSocket {
+  onmessage: ((event: any) => void) | null = null;
+
+  addEventListener() {}
+
+  removeEventListener() {}
+
+  close() {}
+
+  send() {}
+}


### PR DESCRIPTION
## Summary
- add shared create-order param types in the exchange hub and map BitMEX payloads with validation
- implement BitMEX REST order client with retries and wire buy/sell flows in the core
- cover market, limit, post-only and error scenarios with new integration tests

## Testing
- npm run type-check
- npx jest tests/integration/rest --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68cd6978eb7483209bd4d2068ff29f01