### PR TITLE
feat(bitmex): add stop order support and tests

### DIFF
--- a/src/core/bitmex/mappers/order.ts
+++ b/src/core/bitmex/mappers/order.ts
@@ -38,7 +38,7 @@ export function inferOrderType(
   const normalizedAsk = normalizeFinite(bestAsk);
 
   if (side === 'buy') {
-    if (normalizedAsk !== null && normalizedPrice > normalizedAsk) {
+    if (normalizedAsk !== null && normalizedPrice >= normalizedAsk) {
       return 'Stop';
     }
 
@@ -46,7 +46,7 @@ export function inferOrderType(
   }
 
   if (side === 'sell') {
-    if (normalizedBid !== null && normalizedPrice < normalizedBid) {
+    if (normalizedBid !== null && normalizedPrice <= normalizedBid) {
       return 'Stop';
     }
 

--- a/src/core/bitmex/rest/orders.ts
+++ b/src/core/bitmex/rest/orders.ts
@@ -1,0 +1,238 @@
+import { mapBitmexOrderStatus } from '../mappers/order.js';
+import { normalizeWsTs as normalizeTimestamp, parseIsoTs } from '../../../infra/time.js';
+
+import type { PreparedPlaceInput } from '../../../infra/validation.js';
+import type { OrdersRegistry } from '../../exchange-hub.js';
+import type { Order, OrderUpdate } from '../../../domain/order.js';
+import type { BitMexOrder, BitMexPlaceOrderRequest } from '../types.js';
+
+export interface CreateOrderDependencies {
+  orders: OrdersRegistry;
+  submit: (payload: BitMexPlaceOrderRequest) => Promise<BitMexOrder>;
+  now?: () => number;
+}
+
+export async function createOrder(
+  deps: CreateOrderDependencies,
+  input: PreparedPlaceInput,
+): Promise<Order> {
+  const { orders, submit, now } = deps;
+  const clOrdId = input.options.clOrdId;
+  const submittedAt = typeof now === 'function' ? now() : Date.now();
+  const payload = buildCreatePayload(input);
+
+  const restPromise = submit(payload)
+    .then((row) => upsertOrderFromRest(orders, row, { submittedAt }))
+    .finally(() => {
+      orders.clearInflight(clOrdId);
+    });
+
+  orders.registerInflight(clOrdId, restPromise);
+
+  return restPromise;
+}
+
+export function buildCreatePayload(input: PreparedPlaceInput): BitMexPlaceOrderRequest {
+  const { symbol, side, size, type, price, stopPrice, options } = input;
+
+  const payload: BitMexPlaceOrderRequest = {
+    symbol,
+    side: side === 'buy' ? 'Buy' : 'Sell',
+    orderQty: size,
+    ordType: type,
+    clOrdID: options.clOrdId,
+  };
+
+  if ((type === 'Limit' || type === 'StopLimit') && price !== null) {
+    payload.price = price;
+  }
+
+  if ((type === 'Stop' || type === 'StopLimit') && stopPrice !== null) {
+    payload.stopPx = stopPrice;
+  }
+
+  if (options.timeInForce) {
+    payload.timeInForce = options.timeInForce as BitMexPlaceOrderRequest['timeInForce'];
+  }
+
+  const execInst: string[] = [];
+  if (options.postOnly) {
+    execInst.push('ParticipateDoNotInitiate');
+  }
+  if (options.reduceOnly) {
+    execInst.push('ReduceOnly');
+  }
+
+  if (execInst.length > 0) {
+    payload.execInst = execInst.join(',') as BitMexPlaceOrderRequest['execInst'];
+  }
+
+  return payload;
+}
+
+interface UpsertContext {
+  submittedAt: number;
+}
+
+function upsertOrderFromRest(
+  orders: OrdersRegistry,
+  row: BitMexOrder,
+  context: UpsertContext,
+): Order {
+  const orderId = normalizeId(row.orderID);
+  if (!orderId) {
+    throw new Error('BitMEX order response is missing orderID');
+  }
+
+  let order = orders.getByOrderId(orderId);
+  if (!order) {
+    order = orders.create(orderId, { submittedAt: context.submittedAt });
+  }
+
+  const update: OrderUpdate = {};
+
+  const clOrdId = normalizeId(row.clOrdID);
+  if (clOrdId) {
+    update.clOrdId = clOrdId;
+  }
+
+  const symbol = normalizeString(row.symbol);
+  if (symbol) {
+    update.symbol = symbol;
+  }
+
+  const side = normalizeSide(row.side);
+  if (side) {
+    update.side = side;
+  }
+
+  const ordType = normalizeString(row.ordType);
+  if (ordType) {
+    update.type = ordType;
+  }
+
+  const timeInForce = normalizeString(row.timeInForce);
+  if (timeInForce) {
+    update.timeInForce = timeInForce;
+  }
+
+  const execInst = normalizeString(row.execInst);
+  if (execInst) {
+    update.execInst = execInst;
+  }
+
+  if (isFiniteNumber(row.price)) {
+    update.price = row.price;
+  }
+
+  if (isFiniteNumber(row.stopPx)) {
+    update.stopPrice = row.stopPx;
+  }
+
+  if (isFiniteNumber(row.orderQty)) {
+    update.qty = row.orderQty;
+  }
+
+  const leavesQty = normalizeQuantity(row.leavesQty);
+  if (leavesQty !== null) {
+    update.leavesQty = leavesQty;
+  }
+
+  const cumQty = normalizeQuantity(row.cumQty);
+  if (cumQty !== null) {
+    update.cumQty = cumQty;
+  }
+
+  if (isFiniteNumber(row.avgPx)) {
+    update.avgPx = row.avgPx;
+  }
+
+  const text = normalizeString(row.text);
+  if (text) {
+    update.text = text;
+  }
+
+  const status = mapBitmexOrderStatus({
+    ordStatus: row.ordStatus,
+    execType: row.execType,
+    leavesQty,
+    cumQty,
+    previousStatus: order.status,
+  });
+  if (status) {
+    update.status = status;
+  }
+
+  const lastUpdateTs = normalizeTimestampMs(row.transactTime ?? row.timestamp);
+  if (lastUpdateTs !== null) {
+    update.lastUpdateTs = lastUpdateTs;
+  }
+
+  if (!order.getSnapshot().submittedAt && Number.isFinite(context.submittedAt)) {
+    update.submittedAt = context.submittedAt;
+  }
+
+  order.applyUpdate(update);
+  return order;
+}
+
+function normalizeId(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function normalizeString(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function normalizeSide(value: unknown): 'buy' | 'sell' | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  if (normalized === 'buy' || normalized === 'sell') {
+    return normalized;
+  }
+
+  return null;
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+function normalizeQuantity(value: unknown): number | null {
+  if (!isFiniteNumber(value)) {
+    return null;
+  }
+
+  return value;
+}
+
+function normalizeTimestampMs(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const normalized = normalizeTimestamp(value);
+  if (!normalized) {
+    return null;
+  }
+
+  const parsed = parseIsoTs(normalized);
+  return Number.isFinite(parsed) ? parsed : null;
+}

--- a/src/domain/instrument.ts
+++ b/src/domain/instrument.ts
@@ -333,6 +333,8 @@ export class Instrument extends EventEmitter {
       price,
       type,
       opts,
+      bestBid,
+      bestAsk,
     });
 
     const clOrdId = validated.options.clOrdId ?? genClOrdID();

--- a/tests/integration/trading/stop-limit.flagged.spec.ts
+++ b/tests/integration/trading/stop-limit.flagged.spec.ts
@@ -1,0 +1,171 @@
+import { ExchangeHub } from '../../../src/ExchangeHub.js';
+import { handleOrderMessage } from '../../../src/core/bitmex/channels/order.js';
+import { buildCreatePayload, createOrder } from '../../../src/core/bitmex/rest/orders.js';
+import { OrderStatus } from '../../../src/domain/order.js';
+import { validatePlaceInput, type PreparedPlaceInput } from '../../../src/infra/validation.js';
+
+import type { BitMex } from '../../../src/core/bitmex/index.js';
+import type { BitMexOrder } from '../../../src/core/bitmex/types.js';
+
+const ORIGINAL_WEBSOCKET = global.WebSocket;
+
+class StubWebSocket {
+  public readonly url: string;
+  public onopen: (() => void) | null = null;
+  public onmessage: ((event: { data: unknown }) => void) | null = null;
+  public onclose: ((event?: { code?: number; reason?: string }) => void) | null = null;
+  public onerror: ((err: unknown) => void) | null = null;
+
+  constructor(url: string) {
+    this.url = url;
+  }
+
+  addEventListener(): void {}
+  removeEventListener(): void {}
+  send(): void {}
+  close(): void {}
+}
+
+beforeAll(() => {
+  (global as any).WebSocket = StubWebSocket as unknown as typeof WebSocket;
+});
+
+afterAll(() => {
+  (global as any).WebSocket = ORIGINAL_WEBSOCKET;
+});
+
+function createHub() {
+  const hub = new ExchangeHub('BitMex', { isTest: true, apiKey: 'key', apiSec: 'secret' });
+  const core = hub.Core as BitMex;
+  return { hub, core };
+}
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  return { promise, resolve, reject };
+}
+
+describe('BitMEX trading – stop-limit flag', () => {
+  test('upgrades to stop-limit and reconciles race with private update', async () => {
+    const { hub, core } = createHub();
+    const orders = hub.orders;
+
+    handleOrderMessage(core, { table: 'order', action: 'partial', data: [] });
+
+    const normalized = validatePlaceInput({
+      symbol: 'XBTUSD',
+      side: 'sell',
+      size: 5,
+      price: 24_900,
+      type: 'Stop',
+      opts: { clOrdID: 'cli-stop-limit-1', stopLimitPrice: 24_850 },
+      bestBid: 25_000,
+    });
+
+    const prepared: PreparedPlaceInput = {
+      ...normalized,
+      options: { ...normalized.options, clOrdId: 'cli-stop-limit-1' },
+    };
+
+    expect(prepared.type).toBe('StopLimit');
+
+    const expectedPayload = buildCreatePayload(prepared);
+    expect(expectedPayload).toMatchObject({
+      ordType: 'StopLimit',
+      price: 24_850,
+      stopPx: 24_900,
+      side: 'Sell',
+    });
+
+    const deferred = createDeferred<BitMexOrder>();
+    const submit = jest.fn(() => deferred.promise);
+
+    const orderPromise = createOrder({ orders, submit, now: () => 1_700_000_100_000 }, prepared);
+    expect(submit).toHaveBeenCalledTimes(1);
+    expect(submit.mock.calls[0]?.[0]).toEqual(expectedPayload);
+
+    handleOrderMessage(core, {
+      table: 'order',
+      action: 'insert',
+      data: [
+        {
+          orderID: 'ord-stop-limit-1',
+          clOrdID: 'cli-stop-limit-1',
+          symbol: 'XBTUSD',
+          side: 'Sell',
+          orderQty: 5,
+          price: 24_850,
+          stopPx: 24_900,
+          ordType: 'StopLimit',
+          ordStatus: 'New',
+          execType: 'New',
+          leavesQty: 5,
+          cumQty: 0,
+          timestamp: '2024-01-01T00:00:00.000Z',
+        },
+      ],
+    });
+
+    const orderFromWs = orders.getByOrderId('ord-stop-limit-1');
+    expect(orderFromWs).toBeDefined();
+
+    deferred.resolve({
+      orderID: 'ord-stop-limit-1',
+      clOrdID: 'cli-stop-limit-1',
+      symbol: 'XBTUSD',
+      side: 'Sell',
+      orderQty: 5,
+      price: 24_850,
+      stopPx: 24_900,
+      ordType: 'StopLimit',
+      ordStatus: 'New',
+      execType: 'New',
+      leavesQty: 5,
+      cumQty: 0,
+      avgPx: 0,
+      transactTime: '2024-01-01T00:00:01.000Z',
+    });
+
+    const order = await orderPromise;
+    expect(order).toBe(orderFromWs);
+
+    const snapshot = order.getSnapshot();
+    expect(snapshot.type).toBe('StopLimit');
+    expect(snapshot.price).toBe(24_850);
+    expect(snapshot.stopPrice).toBe(24_900);
+    expect(snapshot.status).toBe(OrderStatus.Placed);
+    expect(snapshot.submittedAt).toBe(1_700_000_100_000);
+    expect(orders.getInflightByClOrdId('cli-stop-limit-1')).toBeUndefined();
+
+    handleOrderMessage(core, {
+      table: 'order',
+      action: 'update',
+      data: [
+        {
+          orderID: 'ord-stop-limit-1',
+          clOrdID: 'cli-stop-limit-1',
+          symbol: 'XBTUSD',
+          ordStatus: 'Filled',
+          execType: 'Trade',
+          leavesQty: 0,
+          cumQty: 5,
+          avgPx: 24_860,
+          lastQty: 5,
+          lastPx: 24_860,
+          transactTime: '2024-01-01T00:00:10.000Z',
+        },
+      ],
+    });
+
+    const afterFill = order.getSnapshot();
+    expect(afterFill.status).toBe(OrderStatus.Filled);
+    expect(afterFill.filledQty).toBe(5);
+    expect(afterFill.avgFillPrice).toBe(24_860);
+  });
+});

--- a/tests/integration/trading/stop-market.lifecycle.spec.ts
+++ b/tests/integration/trading/stop-market.lifecycle.spec.ts
@@ -1,0 +1,165 @@
+import { ExchangeHub } from '../../../src/ExchangeHub.js';
+import { handleOrderMessage } from '../../../src/core/bitmex/channels/order.js';
+import { buildCreatePayload, createOrder } from '../../../src/core/bitmex/rest/orders.js';
+import { OrderStatus } from '../../../src/domain/order.js';
+import { validatePlaceInput, type PreparedPlaceInput } from '../../../src/infra/validation.js';
+
+import type { BitMex } from '../../../src/core/bitmex/index.js';
+import type { BitMexOrder } from '../../../src/core/bitmex/types.js';
+
+const ORIGINAL_WEBSOCKET = global.WebSocket;
+
+class StubWebSocket {
+  public readonly url: string;
+  public onopen: (() => void) | null = null;
+  public onmessage: ((event: { data: unknown }) => void) | null = null;
+  public onclose: ((event?: { code?: number; reason?: string }) => void) | null = null;
+  public onerror: ((err: unknown) => void) | null = null;
+
+  constructor(url: string) {
+    this.url = url;
+  }
+
+  addEventListener(): void {}
+  removeEventListener(): void {}
+  send(): void {}
+  close(): void {}
+}
+
+beforeAll(() => {
+  (global as any).WebSocket = StubWebSocket as unknown as typeof WebSocket;
+});
+
+afterAll(() => {
+  (global as any).WebSocket = ORIGINAL_WEBSOCKET;
+});
+
+function createHub() {
+  const hub = new ExchangeHub('BitMex', { isTest: true, apiKey: 'key', apiSec: 'secret' });
+  const core = hub.Core as BitMex;
+  return { hub, core };
+}
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  return { promise, resolve, reject };
+}
+
+describe('BitMEX trading – stop market lifecycle', () => {
+  test('places stop-market order and processes trigger/fill events', async () => {
+    const { hub, core } = createHub();
+    const orders = hub.orders;
+
+    handleOrderMessage(core, { table: 'order', action: 'partial', data: [] });
+
+    const normalized = validatePlaceInput({
+      symbol: 'XBTUSD',
+      side: 'buy',
+      size: 10,
+      price: 30_500,
+      type: 'Stop',
+      opts: { clOrdID: 'cli-stop-1' },
+      bestAsk: 30_000,
+    });
+
+    const prepared: PreparedPlaceInput = {
+      ...normalized,
+      options: { ...normalized.options, clOrdId: 'cli-stop-1' },
+    };
+
+    const expectedPayload = buildCreatePayload(prepared);
+    expect(expectedPayload).toMatchObject({
+      ordType: 'Stop',
+      stopPx: 30_500,
+      side: 'Buy',
+    });
+    expect(expectedPayload.price).toBeUndefined();
+
+    const deferred = createDeferred<BitMexOrder>();
+    const submit = jest.fn(() => deferred.promise);
+
+    const orderPromise = createOrder({ orders, submit, now: () => 1_700_000_000_000 }, prepared);
+    expect(submit).toHaveBeenCalledTimes(1);
+    expect(submit.mock.calls[0]?.[0]).toEqual(expectedPayload);
+    expect(orders.getInflightByClOrdId('cli-stop-1')).toBeDefined();
+
+    deferred.resolve({
+      orderID: 'ord-stop-1',
+      clOrdID: 'cli-stop-1',
+      symbol: 'XBTUSD',
+      side: 'Buy',
+      orderQty: 10,
+      stopPx: 30_500,
+      ordType: 'Stop',
+      ordStatus: 'New',
+      execType: 'New',
+      leavesQty: 10,
+      cumQty: 0,
+      avgPx: 0,
+      transactTime: '2024-01-01T00:00:00.000Z',
+    });
+
+    const order = await orderPromise;
+    expect(order).toBeDefined();
+
+    expect(orders.getInflightByClOrdId('cli-stop-1')).toBeUndefined();
+
+    const snapshot = order.getSnapshot();
+    expect(snapshot.status).toBe(OrderStatus.Placed);
+    expect(snapshot.stopPrice).toBe(30_500);
+    expect(snapshot.price).toBeNull();
+    expect(snapshot.submittedAt).toBe(1_700_000_000_000);
+
+    handleOrderMessage(core, {
+      table: 'order',
+      action: 'update',
+      data: [
+        {
+          orderID: 'ord-stop-1',
+          clOrdID: 'cli-stop-1',
+          symbol: 'XBTUSD',
+          ordStatus: 'Triggered',
+          execType: 'New',
+          stopPx: 30_500,
+          timestamp: '2024-01-01T00:00:05.000Z',
+        },
+      ],
+    });
+
+    const afterTrigger = order.getSnapshot();
+    expect(afterTrigger.status).toBe(OrderStatus.Placed);
+    expect(afterTrigger.stopPrice).toBe(30_500);
+
+    handleOrderMessage(core, {
+      table: 'order',
+      action: 'update',
+      data: [
+        {
+          orderID: 'ord-stop-1',
+          clOrdID: 'cli-stop-1',
+          symbol: 'XBTUSD',
+          ordStatus: 'Filled',
+          execType: 'Trade',
+          leavesQty: 0,
+          cumQty: 10,
+          avgPx: 30_520,
+          lastQty: 10,
+          lastPx: 30_520,
+          transactTime: '2024-01-01T00:00:10.000Z',
+        },
+      ],
+    });
+
+    const afterFill = order.getSnapshot();
+    expect(afterFill.status).toBe(OrderStatus.Filled);
+    expect(afterFill.filledQty).toBe(10);
+    expect(afterFill.avgFillPrice).toBe(30_520);
+    expect(afterFill.stopPrice).toBe(30_500);
+  });
+});

--- a/tests/unit/core/mappers/order-type.spec.ts
+++ b/tests/unit/core/mappers/order-type.spec.ts
@@ -14,6 +14,7 @@ describe('inferOrderType', () => {
   test('classifies buy stop zone above best ask', () => {
     expect(inferOrderType('buy', 106, 95, 105)).toBe('Stop');
     expect(inferOrderType('buy', 120, undefined, 110)).toBe('Stop');
+    expect(inferOrderType('buy', 105, 95, 105)).toBe('Stop');
   });
 
   test('classifies sell limit zone at or above best bid', () => {
@@ -24,6 +25,7 @@ describe('inferOrderType', () => {
   test('classifies sell stop zone below best bid', () => {
     expect(inferOrderType('sell', 98, 100, 110)).toBe('Stop');
     expect(inferOrderType('sell', 50, 60, undefined)).toBe('Stop');
+    expect(inferOrderType('sell', 100, 100, 110)).toBe('Stop');
   });
 
   test('defaults to limit when no book context is available', () => {

--- a/tests/unit/infra/validation/place-input.spec.ts
+++ b/tests/unit/infra/validation/place-input.spec.ts
@@ -49,6 +49,35 @@ describe('validatePlaceInput', () => {
     expect(result.options.reduceOnly).toBe(true);
   });
 
+  test('promotes stop order with stop-limit flag to StopLimit type', () => {
+    const result = validatePlaceInput({
+      symbol: 'XBTUSD',
+      side: 'buy',
+      size: 3,
+      price: 30_100,
+      type: 'Stop',
+      opts: { stopLimitPrice: 30_150 },
+      bestAsk: 30_000,
+    });
+
+    expect(result.type).toBe('StopLimit');
+    expect(result.stopPrice).toBe(30_100);
+    expect(result.price).toBe(30_150);
+  });
+
+  test('throws when buy stop price is below best ask', () => {
+    expect(() =>
+      validatePlaceInput({
+        symbol: 'XBTUSD',
+        side: 'buy',
+        size: 1,
+        price: 29_900,
+        type: 'Stop',
+        bestAsk: 30_000,
+      }),
+    ).toThrow(ValidationError);
+  });
+
   test('throws when market order carries price', () => {
     expect(() =>
       validatePlaceInput({


### PR DESCRIPTION
## Summary
- adjust stop classification and validation to support stop-limit inputs and enforce stop zone checks
- add BitMEX REST order payload builder and reconciliation logic for stop-market and stop-limit orders
- cover stop workflows with unit tests and new integration lifecycles, including race conditions

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd71c029348320a16a73c26ce554cc