### PR TITLE
feat(bitmex): REST create order + payload mapping (market/limit/postOnly)

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,9 @@ BitMEX и большинство бирж требуют, чтобы `clOrdID` �
 ```ts
 import { ExchangeHub, genClOrdID } from 'exchange-hub';
 
-export const eh = new ExchangeHub('BitMex', { /*...*/ });
+export const eh = new ExchangeHub('BitMex', {
+  /*...*/
+});
 // Рекомендуется задавать уникальный префикс для clOrdID через переменную окружения:
 // EH_PREFIX=my-desk-01
 const clOrdID = genClOrdID(process.env.EH_PREFIX);

--- a/src/core/bitmex/index.ts
+++ b/src/core/bitmex/index.ts
@@ -11,7 +11,8 @@ import type { CreateOrderPayload } from './rest/orders.js';
 import { BaseCore } from '../BaseCore.js';
 import { getUnifiedSymbolAliases, mapSymbolNativeToUni } from '../../utils/symbolMapping.js';
 import { Instrument } from '../../domain/instrument.js';
-import { Order, OrderStatus, type OrderInit, type OrderUpdate } from '../../domain/order.js';
+import type { Order } from '../../domain/order.js';
+import { OrderStatus, type OrderInit, type OrderUpdate } from '../../domain/order.js';
 import { createLogger } from '../../infra/logger.js';
 import { ValidationError } from '../../infra/errors.js';
 import type { PreparedPlaceInput } from '../../infra/validation.js';
@@ -263,7 +264,9 @@ export class BitMex extends BaseCore<'BitMex'> {
         leavesQty: leavesQty ?? null,
         cumQty: cumQty ?? null,
         previousStatus: order?.status ?? null,
-      }) ?? order?.status ?? OrderStatus.Placed;
+      }) ??
+      order?.status ??
+      OrderStatus.Placed;
 
     const update: OrderUpdate = { status };
 

--- a/src/core/bitmex/index.ts
+++ b/src/core/bitmex/index.ts
@@ -3,11 +3,18 @@ import { channelMessageHandlers } from './channelMessageHandlers/index.js';
 import { isChannelMessage, isSubscribeMessage, isWelcomeMessage } from './utils.js';
 import { L2_CHANNEL, L2_MAX_DEPTH_HINT } from './constants.js';
 import { markOrderChannelAwaitingSnapshot } from './channels/order.js';
+import { BitmexRestClient } from './rest/request.js';
+import { createOrder, BITMEX_CREATE_ORDER_TIMEOUT_MS } from './rest/orders.js';
+import { mapBitmexOrderStatus, mapPreparedOrderToCreatePayload } from './mappers/order.js';
+import type { CreateOrderPayload } from './rest/orders.js';
 
 import { BaseCore } from '../BaseCore.js';
 import { getUnifiedSymbolAliases, mapSymbolNativeToUni } from '../../utils/symbolMapping.js';
 import { Instrument } from '../../domain/instrument.js';
+import { Order, OrderStatus, type OrderInit, type OrderUpdate } from '../../domain/order.js';
 import { createLogger } from '../../infra/logger.js';
+import { ValidationError } from '../../infra/errors.js';
+import type { PreparedPlaceInput } from '../../infra/validation.js';
 import type { Settings } from '../../types.js';
 import type { ExchangeHub } from '../../ExchangeHub.js';
 import type {
@@ -15,12 +22,14 @@ import type {
   BitMexChannelMessage,
   BitMexSubscribeMessage,
   BitMexWelcomeMessage,
+  BitMexOrder,
 } from './types.js';
 
 export class BitMex extends BaseCore<'BitMex'> {
   #log = createLogger('bitmex:core');
   #settings: Settings;
   #transport: BitMexTransport;
+  #rest: BitmexRestClient;
   #symbolMappingEnabled: boolean;
   #instruments = new Map<string, Instrument>();
   #instrumentsByNative = new Map<string, Instrument>();
@@ -34,6 +43,11 @@ export class BitMex extends BaseCore<'BitMex'> {
     this.#transport = new BitMexTransport(settings.isTest ?? false, (message) =>
       this.#handleMessage(message),
     );
+    this.#rest = new BitmexRestClient({
+      isTest: settings.isTest ?? false,
+      apiKey: settings.apiKey,
+      apiSecret: settings.apiSec,
+    });
   }
 
   override get instruments(): Map<string, Instrument> {
@@ -118,6 +132,26 @@ export class BitMex extends BaseCore<'BitMex'> {
     this.#removeInstrumentKeys(instrument);
   }
 
+  buy(prepared: PreparedPlaceInput): Promise<Order> {
+    if (prepared.side !== 'buy') {
+      throw new ValidationError('BitMEX buy() expects payload with side "buy"', {
+        details: { side: prepared.side },
+      });
+    }
+
+    return this.#submitOrder(prepared);
+  }
+
+  sell(prepared: PreparedPlaceInput): Promise<Order> {
+    if (prepared.side !== 'sell') {
+      throw new ValidationError('BitMEX sell() expects payload with side "sell"', {
+        details: { side: prepared.side },
+      });
+    }
+
+    return this.#submitOrder(prepared);
+  }
+
   #registerInstrumentKeys(instrument: Instrument): void {
     const existingKeys = this.#instrumentKeys.get(instrument);
 
@@ -167,6 +201,165 @@ export class BitMex extends BaseCore<'BitMex'> {
     }
 
     this.#instrumentKeys.delete(instrument);
+  }
+
+  #submitOrder(prepared: PreparedPlaceInput): Promise<Order> {
+    let payload: CreateOrderPayload;
+    try {
+      payload = mapPreparedOrderToCreatePayload(prepared);
+    } catch (error) {
+      return Promise.reject(error);
+    }
+    const store = this.shell.orders;
+
+    const inflight = store.getInflightByClOrdId(payload.clOrdID);
+    if (inflight) {
+      return inflight;
+    }
+
+    const existing = store.getByClOrdId(payload.clOrdID);
+    if (existing) {
+      return Promise.resolve(existing);
+    }
+
+    const orderPromise = (async () => {
+      try {
+        const restOrder = await createOrder(this.#rest, payload, {
+          timeoutMs: BITMEX_CREATE_ORDER_TIMEOUT_MS,
+          retries: 1,
+          logger: this.#log,
+        });
+        return this.#upsertOrderFromRest(restOrder);
+      } finally {
+        store.clearInflight(payload.clOrdID);
+      }
+    })();
+
+    store.registerInflight(payload.clOrdID, orderPromise);
+
+    return orderPromise;
+  }
+
+  #upsertOrderFromRest(row: BitMexOrder): Order {
+    const store = this.shell.orders;
+    const orderId = normalizeId(row.orderID);
+
+    if (!orderId) {
+      throw new ValidationError('BitMEX createOrder response missing orderID', {
+        details: { clOrdID: row.clOrdID, symbol: row.symbol },
+      });
+    }
+
+    const clOrdId = normalizeId(row.clOrdID);
+    const order = store.resolve(orderId, clOrdId);
+
+    const leavesQty = normalizeNumber(row.leavesQty);
+    const cumQty = normalizeNumber(row.cumQty);
+
+    const status =
+      mapBitmexOrderStatus({
+        ordStatus: row.ordStatus,
+        execType: row.execType,
+        leavesQty: leavesQty ?? null,
+        cumQty: cumQty ?? null,
+        previousStatus: order?.status ?? null,
+      }) ?? order?.status ?? OrderStatus.Placed;
+
+    const update: OrderUpdate = { status };
+
+    if (clOrdId) {
+      update.clOrdId = clOrdId;
+    }
+
+    const symbol = normalizeSymbol(row.symbol);
+    if (symbol) {
+      update.symbol = symbol;
+    }
+
+    const side = normalizeSide(row.side);
+    if (side) {
+      update.side = side;
+    }
+
+    const ordType = normalizeString(row.ordType);
+    if (ordType) {
+      update.type = ordType;
+    }
+
+    const timeInForce = normalizeString(row.timeInForce);
+    if (timeInForce) {
+      update.timeInForce = timeInForce;
+    }
+
+    const execInst = normalizeString(row.execInst);
+    if (execInst) {
+      update.execInst = execInst;
+    }
+
+    const price = normalizeNumber(row.price);
+    if (price !== undefined) {
+      update.price = price;
+    }
+
+    const stopPx = normalizeNumber(row.stopPx);
+    if (stopPx !== undefined) {
+      update.stopPrice = stopPx;
+    }
+
+    const qty = normalizeNumber(row.orderQty);
+    if (qty !== undefined) {
+      update.qty = qty;
+    }
+
+    if (leavesQty !== undefined) {
+      update.leavesQty = leavesQty;
+    }
+
+    if (cumQty !== undefined) {
+      update.cumQty = cumQty;
+    }
+
+    const avgPx = normalizeNumber(row.avgPx);
+    if (avgPx !== undefined) {
+      update.avgPx = avgPx;
+    }
+
+    const text = normalizeString(row.text);
+    if (text) {
+      update.text = text;
+    }
+
+    const lastUpdateTs = normalizeTimestampMs(row.transactTime ?? row.timestamp);
+    if (lastUpdateTs !== null) {
+      update.lastUpdateTs = lastUpdateTs;
+    }
+
+    if (order) {
+      order.applyUpdate(update);
+      return order;
+    }
+
+    const init: OrderInit = {
+      orderId,
+      status,
+      clOrdId: clOrdId ?? undefined,
+      symbol: update.symbol,
+      side: update.side,
+      type: update.type,
+      timeInForce: update.timeInForce,
+      execInst: update.execInst,
+      price: update.price,
+      stopPrice: update.stopPrice,
+      qty: update.qty,
+      leavesQty: update.leavesQty,
+      filledQty: update.cumQty,
+      avgFillPrice: update.avgPx,
+      text: update.text,
+      lastUpdateTs: update.lastUpdateTs,
+      submittedAt: update.lastUpdateTs,
+    };
+
+    return store.create(orderId, init);
   }
 
   async connect(): Promise<void> {
@@ -229,4 +422,60 @@ export class BitMex extends BaseCore<'BitMex'> {
 
     channelMessageHandlers[table][action](this, data);
   }
+}
+
+function normalizeId(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function normalizeSymbol(value: unknown): string | null {
+  return normalizeId(value);
+}
+
+function normalizeSide(value: unknown): 'buy' | 'sell' | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  if (normalized === 'buy' || normalized === 'sell') {
+    return normalized as 'buy' | 'sell';
+  }
+
+  return null;
+}
+
+function normalizeString(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function normalizeNumber(value: unknown): number | undefined {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return undefined;
+  }
+
+  return value;
+}
+
+function normalizeTimestampMs(value: unknown): number | null {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : null;
+  }
+
+  if (typeof value === 'string') {
+    const parsed = Date.parse(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+
+  return null;
 }

--- a/src/core/bitmex/mappers/order.ts
+++ b/src/core/bitmex/mappers/order.ts
@@ -84,7 +84,9 @@ function normalizeFinite(value: number | null | undefined): number | null {
 
 export function mapPreparedOrderToCreatePayload(input: PreparedPlaceInput): CreateOrderPayload {
   if (input.type === 'Stop') {
-    throw new ValidationError('Stop orders are not supported yet', { details: { type: input.type } });
+    throw new ValidationError('Stop orders are not supported yet', {
+      details: { type: input.type },
+    });
   }
 
   const side = input.side === 'sell' ? 'Sell' : 'Buy';

--- a/src/core/bitmex/mappers/order.ts
+++ b/src/core/bitmex/mappers/order.ts
@@ -1,8 +1,12 @@
 import { OrderStatus } from '../../../domain/order.js';
+import { ValidationError } from '../../../infra/errors.js';
+
+import type { PreparedPlaceInput } from '../../../infra/validation.js';
 
 import type { BitMexExecType, BitMexOrderStatus } from '../types.js';
 import type { Side } from '../../../types.js';
 import type { OrderType } from '../../../infra/validation.js';
+import type { CreateOrderPayload } from '../rest/orders.js';
 
 export type BitmexOrderStatusInput = {
   ordStatus?: BitMexOrderStatus | null;
@@ -76,6 +80,51 @@ function normalizeFinite(value: number | null | undefined): number | null {
   }
 
   return Number.isFinite(value) ? value : null;
+}
+
+export function mapPreparedOrderToCreatePayload(input: PreparedPlaceInput): CreateOrderPayload {
+  if (input.type === 'Stop') {
+    throw new ValidationError('Stop orders are not supported yet', { details: { type: input.type } });
+  }
+
+  const side = input.side === 'sell' ? 'Sell' : 'Buy';
+  const payload: CreateOrderPayload = {
+    symbol: input.symbol,
+    side,
+    orderQty: input.size,
+    ordType: input.type,
+    clOrdID: input.options.clOrdId,
+  };
+
+  if (input.type === 'Limit') {
+    if (input.price === null) {
+      throw new ValidationError('limit order requires price', { details: { type: input.type } });
+    }
+
+    payload.price = input.price;
+  }
+
+  if (input.stopPrice !== null && input.stopPrice !== undefined) {
+    payload.stopPx = input.stopPrice;
+  }
+
+  const execInst: string[] = [];
+  if (input.options.postOnly) {
+    execInst.push('ParticipateDoNotInitiate');
+  }
+  if (input.options.reduceOnly) {
+    execInst.push('ReduceOnly');
+  }
+
+  if (execInst.length > 0) {
+    payload.execInst = execInst.join(',');
+  }
+
+  if (input.options.timeInForce) {
+    payload.timeInForce = input.options.timeInForce as CreateOrderPayload['timeInForce'];
+  }
+
+  return payload;
 }
 
 export function mapBitmexOrderStatus({

--- a/src/core/bitmex/rest/orders.ts
+++ b/src/core/bitmex/rest/orders.ts
@@ -1,0 +1,90 @@
+import { createLogger, type Logger } from '../../../infra/logger.js';
+import { ExchangeDownError, NetworkError } from '../../../infra/errors.js';
+
+import type { BitMexOrder, BitMexOrderType, BitMexSide, BitMexTimeInForce } from '../types.js';
+
+import { BitmexRestClient } from './request.js';
+
+export interface CreateOrderPayload {
+  symbol: string;
+  side: BitMexSide;
+  orderQty: number;
+  ordType: Extract<BitMexOrderType, 'Market' | 'Limit' | 'Stop'>;
+  clOrdID: string;
+  price?: number;
+  stopPx?: number;
+  execInst?: string;
+  timeInForce?: BitMexTimeInForce;
+}
+
+export interface CreateOrderOptions {
+  timeoutMs?: number;
+  retries?: number;
+  logger?: Logger;
+}
+
+export const BITMEX_CREATE_ORDER_TIMEOUT_MS = 8_000;
+const DEFAULT_RETRIES = 1;
+
+const log = createLogger('bitmex:rest:orders');
+
+export async function createOrder(
+  client: BitmexRestClient,
+  payload: CreateOrderPayload,
+  options: CreateOrderOptions = {},
+): Promise<BitMexOrder> {
+  const { timeoutMs = BITMEX_CREATE_ORDER_TIMEOUT_MS, retries = DEFAULT_RETRIES, logger } = options;
+  const attemptLogger = logger ?? log;
+  const body: Record<string, unknown> = {
+    symbol: payload.symbol,
+    side: payload.side,
+    orderQty: payload.orderQty,
+    ordType: payload.ordType,
+    clOrdID: payload.clOrdID,
+  };
+
+  if (payload.price !== undefined) {
+    body.price = payload.price;
+  }
+  if (payload.stopPx !== undefined) {
+    body.stopPx = payload.stopPx;
+  }
+  if (payload.execInst) {
+    body.execInst = payload.execInst;
+  }
+  if (payload.timeInForce) {
+    body.timeInForce = payload.timeInForce;
+  }
+
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt <= Math.max(0, retries); attempt += 1) {
+    try {
+      return await client.request<BitMexOrder>('POST', '/api/v1/order', {
+        auth: true,
+        body,
+        timeoutMs,
+      });
+    } catch (error) {
+      lastError = error;
+
+      if (!(error instanceof NetworkError || error instanceof ExchangeDownError)) {
+        throw error;
+      }
+
+      if (attempt >= retries) {
+        throw error;
+      }
+
+      attemptLogger.warn('BitMEX createOrder retry %d/%d after %s', attempt + 1, retries, error.message, {
+        attempt: attempt + 1,
+        retries,
+        code: error.code,
+        clOrdID: payload.clOrdID,
+        symbol: payload.symbol,
+      });
+    }
+  }
+
+  throw lastError instanceof Error ? lastError : new NetworkError('BitMEX createOrder failed');
+}

--- a/src/core/bitmex/rest/orders.ts
+++ b/src/core/bitmex/rest/orders.ts
@@ -3,7 +3,7 @@ import { ExchangeDownError, NetworkError } from '../../../infra/errors.js';
 
 import type { BitMexOrder, BitMexOrderType, BitMexSide, BitMexTimeInForce } from '../types.js';
 
-import { BitmexRestClient } from './request.js';
+import type { BitmexRestClient } from './request.js';
 
 export interface CreateOrderPayload {
   symbol: string;
@@ -76,13 +76,19 @@ export async function createOrder(
         throw error;
       }
 
-      attemptLogger.warn('BitMEX createOrder retry %d/%d after %s', attempt + 1, retries, error.message, {
-        attempt: attempt + 1,
+      attemptLogger.warn(
+        'BitMEX createOrder retry %d/%d after %s',
+        attempt + 1,
         retries,
-        code: error.code,
-        clOrdID: payload.clOrdID,
-        symbol: payload.symbol,
-      });
+        error.message,
+        {
+          attempt: attempt + 1,
+          retries,
+          code: error.code,
+          clOrdID: payload.clOrdID,
+          symbol: payload.symbol,
+        },
+      );
     }
   }
 

--- a/tests/integration/rest/create-order.limit-postonly.spec.ts
+++ b/tests/integration/rest/create-order.limit-postonly.spec.ts
@@ -1,0 +1,128 @@
+import { jest } from '@jest/globals';
+
+import { ExchangeHub } from '../../../src/ExchangeHub.js';
+import { OrderStatus } from '../../../src/domain/order.js';
+
+import type { BitMex } from '../../../src/core/bitmex/index.js';
+import type { PreparedPlaceInput } from '../../../src/infra/validation.js';
+
+const ORIGINAL_FETCH = global.fetch;
+
+function createHub() {
+  const hub = new ExchangeHub('BitMex', { isTest: true, apiKey: 'key', apiSec: 'secret' });
+  const core = hub.Core as BitMex;
+  return { hub, core };
+}
+
+describe('BitMEX REST createOrder – limit/postOnly', () => {
+  afterEach(() => {
+    global.fetch = ORIGINAL_FETCH;
+    jest.restoreAllMocks();
+  });
+
+  test('submits limit payload with price and timeInForce', async () => {
+    const mockFetch = jest.fn(async () =>
+      new Response(
+        JSON.stringify({
+          orderID: 'ord-10',
+          clOrdID: 'cli-10',
+          symbol: 'XBTUSD',
+          side: 'Sell',
+          orderQty: 5,
+          price: 61_000,
+          ordType: 'Limit',
+          ordStatus: 'New',
+          execType: 'New',
+          leavesQty: 5,
+          cumQty: 0,
+          avgPx: 0,
+          timestamp: '2024-01-01T00:00:00.000Z',
+        }),
+        { status: 200 },
+      ),
+    );
+    global.fetch = mockFetch as unknown as typeof fetch;
+
+    const { hub, core } = createHub();
+    const prepared: PreparedPlaceInput = {
+      symbol: 'XBTUSD',
+      side: 'sell',
+      size: 5,
+      type: 'Limit',
+      price: 61_000,
+      stopPrice: null,
+      options: {
+        postOnly: false,
+        reduceOnly: false,
+        timeInForce: 'GoodTillCancel',
+        clOrdId: 'cli-10',
+      },
+    };
+
+    const order = await core.sell(prepared);
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [, init] = mockFetch.mock.calls[0] as [RequestInfo | URL, RequestInit];
+    const body = JSON.parse(String(init.body));
+    expect(body).toMatchObject({
+      symbol: 'XBTUSD',
+      side: 'Sell',
+      orderQty: 5,
+      price: 61_000,
+      ordType: 'Limit',
+      clOrdID: 'cli-10',
+      timeInForce: 'GoodTillCancel',
+    });
+
+    const snapshot = order.getSnapshot();
+    expect(snapshot.status).toBe(OrderStatus.Placed);
+    expect(snapshot.price).toBe(61_000);
+    expect(hub.orders.getByClOrdId('cli-10')).toBe(order);
+  });
+
+  test('maps postOnly and reduceOnly to execInst', async () => {
+    const mockFetch = jest.fn(async () =>
+      new Response(
+        JSON.stringify({
+          orderID: 'ord-11',
+          clOrdID: 'cli-11',
+          symbol: 'XBTUSD',
+          side: 'Buy',
+          orderQty: 3,
+          price: 60_500,
+          ordType: 'Limit',
+          ordStatus: 'New',
+          execType: 'New',
+          leavesQty: 3,
+          cumQty: 0,
+          avgPx: 0,
+          timestamp: '2024-01-01T00:00:00.000Z',
+        }),
+        { status: 200 },
+      ),
+    );
+    global.fetch = mockFetch as unknown as typeof fetch;
+
+    const { core } = createHub();
+    const prepared: PreparedPlaceInput = {
+      symbol: 'XBTUSD',
+      side: 'buy',
+      size: 3,
+      type: 'Limit',
+      price: 60_500,
+      stopPrice: null,
+      options: {
+        postOnly: true,
+        reduceOnly: true,
+        timeInForce: null,
+        clOrdId: 'cli-11',
+      },
+    };
+
+    await core.buy(prepared);
+
+    const [, init] = mockFetch.mock.calls[0] as [RequestInfo | URL, RequestInit];
+    const body = JSON.parse(String(init.body));
+    expect(body.execInst).toBe('ParticipateDoNotInitiate,ReduceOnly');
+  });
+});

--- a/tests/integration/rest/create-order.limit-postonly.spec.ts
+++ b/tests/integration/rest/create-order.limit-postonly.spec.ts
@@ -21,25 +21,26 @@ describe('BitMEX REST createOrder – limit/postOnly', () => {
   });
 
   test('submits limit payload with price and timeInForce', async () => {
-    const mockFetch = jest.fn(async () =>
-      new Response(
-        JSON.stringify({
-          orderID: 'ord-10',
-          clOrdID: 'cli-10',
-          symbol: 'XBTUSD',
-          side: 'Sell',
-          orderQty: 5,
-          price: 61_000,
-          ordType: 'Limit',
-          ordStatus: 'New',
-          execType: 'New',
-          leavesQty: 5,
-          cumQty: 0,
-          avgPx: 0,
-          timestamp: '2024-01-01T00:00:00.000Z',
-        }),
-        { status: 200 },
-      ),
+    const mockFetch = jest.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            orderID: 'ord-10',
+            clOrdID: 'cli-10',
+            symbol: 'XBTUSD',
+            side: 'Sell',
+            orderQty: 5,
+            price: 61_000,
+            ordType: 'Limit',
+            ordStatus: 'New',
+            execType: 'New',
+            leavesQty: 5,
+            cumQty: 0,
+            avgPx: 0,
+            timestamp: '2024-01-01T00:00:00.000Z',
+          }),
+          { status: 200 },
+        ),
     );
     global.fetch = mockFetch as unknown as typeof fetch;
 
@@ -81,25 +82,26 @@ describe('BitMEX REST createOrder – limit/postOnly', () => {
   });
 
   test('maps postOnly and reduceOnly to execInst', async () => {
-    const mockFetch = jest.fn(async () =>
-      new Response(
-        JSON.stringify({
-          orderID: 'ord-11',
-          clOrdID: 'cli-11',
-          symbol: 'XBTUSD',
-          side: 'Buy',
-          orderQty: 3,
-          price: 60_500,
-          ordType: 'Limit',
-          ordStatus: 'New',
-          execType: 'New',
-          leavesQty: 3,
-          cumQty: 0,
-          avgPx: 0,
-          timestamp: '2024-01-01T00:00:00.000Z',
-        }),
-        { status: 200 },
-      ),
+    const mockFetch = jest.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            orderID: 'ord-11',
+            clOrdID: 'cli-11',
+            symbol: 'XBTUSD',
+            side: 'Buy',
+            orderQty: 3,
+            price: 60_500,
+            ordType: 'Limit',
+            ordStatus: 'New',
+            execType: 'New',
+            leavesQty: 3,
+            cumQty: 0,
+            avgPx: 0,
+            timestamp: '2024-01-01T00:00:00.000Z',
+          }),
+          { status: 200 },
+        ),
     );
     global.fetch = mockFetch as unknown as typeof fetch;
 

--- a/tests/integration/rest/create-order.market.spec.ts
+++ b/tests/integration/rest/create-order.market.spec.ts
@@ -1,0 +1,254 @@
+import { jest } from '@jest/globals';
+
+import { ExchangeHub } from '../../../src/ExchangeHub.js';
+import { OrderStatus } from '../../../src/domain/order.js';
+import { RateLimitError, ValidationError } from '../../../src/infra/errors.js';
+
+import type { BitMex } from '../../../src/core/bitmex/index.js';
+import type { PreparedPlaceInput } from '../../../src/infra/validation.js';
+
+const ORIGINAL_FETCH = global.fetch;
+
+function createPreparedMarketOrder(overrides: Partial<PreparedPlaceInput> = {}): PreparedPlaceInput {
+  return {
+    symbol: 'XBTUSD',
+    side: 'buy',
+    size: 100,
+    type: 'Market',
+    price: null,
+    stopPrice: null,
+    options: {
+      postOnly: false,
+      reduceOnly: false,
+      timeInForce: null,
+      clOrdId: 'cli-1',
+    },
+    ...overrides,
+  };
+}
+
+function createHub() {
+  const hub = new ExchangeHub('BitMex', { isTest: true, apiKey: 'key', apiSec: 'secret' });
+  const core = hub.Core as BitMex;
+  return { hub, core };
+}
+
+describe('BitMEX REST createOrder – market', () => {
+  afterEach(() => {
+    global.fetch = ORIGINAL_FETCH;
+    jest.restoreAllMocks();
+  });
+
+  test('submits market payload and stores order snapshot', async () => {
+    const mockFetch = jest.fn(async () =>
+      new Response(
+        JSON.stringify({
+          orderID: 'ord-1',
+          clOrdID: 'cli-1',
+          symbol: 'XBTUSD',
+          side: 'Buy',
+          orderQty: 100,
+          ordType: 'Market',
+          ordStatus: 'New',
+          execType: 'New',
+          leavesQty: 100,
+          cumQty: 0,
+          avgPx: 0,
+          timestamp: '2024-01-01T00:00:00.000Z',
+        }),
+        { status: 200 },
+      ),
+    );
+    global.fetch = mockFetch as unknown as typeof fetch;
+
+    const { hub, core } = createHub();
+    const prepared = createPreparedMarketOrder();
+
+    const order = await core.buy(prepared);
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [url, init] = mockFetch.mock.calls[0] as [RequestInfo | URL, RequestInit];
+    expect(String(url)).toBe('https://testnet.bitmex.com/api/v1/order');
+    expect(init.method).toBe('POST');
+    const headers = init.headers as Record<string, string>;
+    expect(headers['content-type']).toBe('application/json');
+    expect(headers['api-key']).toBe('key');
+    const body = JSON.parse(String(init.body));
+    expect(body).toMatchObject({
+      symbol: 'XBTUSD',
+      side: 'Buy',
+      orderQty: 100,
+      ordType: 'Market',
+      clOrdID: 'cli-1',
+    });
+    expect(body).not.toHaveProperty('price');
+
+    const snapshot = order.getSnapshot();
+    expect(snapshot.orderId).toBe('ord-1');
+    expect(snapshot.status).toBe(OrderStatus.Placed);
+    expect(snapshot.symbol).toBe('XBTUSD');
+    expect(hub.orders.getByClOrdId('cli-1')).toBe(order);
+    expect(hub.orders.getInflightByClOrdId('cli-1')).toBeUndefined();
+  });
+
+  test('retries once on network failure', async () => {
+    const responses = [
+      Promise.reject(new TypeError('network down')),
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            orderID: 'ord-2',
+            clOrdID: 'cli-2',
+            symbol: 'XBTUSD',
+            side: 'Buy',
+            orderQty: 50,
+            ordType: 'Market',
+            ordStatus: 'New',
+            execType: 'New',
+            leavesQty: 50,
+            cumQty: 0,
+            avgPx: 0,
+            timestamp: '2024-01-01T00:00:00.000Z',
+          }),
+          { status: 200 },
+        ),
+      ),
+    ];
+
+    const mockFetch = jest.fn(() => responses.shift() as Promise<Response>);
+    global.fetch = mockFetch as unknown as typeof fetch;
+
+    const { core } = createHub();
+    const prepared = createPreparedMarketOrder({
+      options: { ...createPreparedMarketOrder().options, clOrdId: 'cli-2' },
+    });
+
+    const order = await core.buy(prepared);
+    expect(order.getSnapshot().orderId).toBe('ord-2');
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  test('retries once on exchange 5xx', async () => {
+    const mockFetch = jest
+      .fn()
+      .mockResolvedValueOnce(new Response('oops', { status: 503 }))
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            orderID: 'ord-3',
+            clOrdID: 'cli-3',
+            symbol: 'XBTUSD',
+            side: 'Buy',
+            orderQty: 25,
+            ordType: 'Market',
+            ordStatus: 'New',
+            execType: 'New',
+            leavesQty: 25,
+            cumQty: 0,
+            avgPx: 0,
+            timestamp: '2024-01-01T00:00:00.000Z',
+          }),
+          { status: 200 },
+        ),
+      );
+    global.fetch = mockFetch as unknown as typeof fetch;
+
+    const { core } = createHub();
+    const prepared = createPreparedMarketOrder({
+      options: { ...createPreparedMarketOrder().options, clOrdId: 'cli-3' },
+    });
+
+    await core.buy(prepared);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  test('does not retry on 429', async () => {
+    const mockFetch = jest.fn(async () =>
+      new Response('Too many', {
+        status: 429,
+        headers: { 'Retry-After': '1' },
+      }),
+    );
+    global.fetch = mockFetch as unknown as typeof fetch;
+
+    const { hub, core } = createHub();
+    const prepared = createPreparedMarketOrder({
+      options: { ...createPreparedMarketOrder().options, clOrdId: 'cli-4' },
+    });
+
+    await expect(core.buy(prepared)).rejects.toBeInstanceOf(RateLimitError);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(hub.orders.getInflightByClOrdId('cli-4')).toBeUndefined();
+  });
+
+  test('shares inflight promise for the same clOrdId and returns cached order afterwards', async () => {
+    const mockFetch = jest.fn(
+      () =>
+        new Promise<Response>((resolve) => {
+          setTimeout(() => {
+            resolve(
+              new Response(
+                JSON.stringify({
+                  orderID: 'ord-5',
+                  clOrdID: 'cli-5',
+                  symbol: 'XBTUSD',
+                  side: 'Buy',
+                  orderQty: 10,
+                  ordType: 'Market',
+                  ordStatus: 'New',
+                  execType: 'New',
+                  leavesQty: 10,
+                  cumQty: 0,
+                  avgPx: 0,
+                  timestamp: '2024-01-01T00:00:00.000Z',
+                }),
+                { status: 200 },
+              ),
+            );
+          }, 0);
+        }),
+    );
+    global.fetch = mockFetch as unknown as typeof fetch;
+
+    const { core } = createHub();
+    const prepared = createPreparedMarketOrder({
+      options: { ...createPreparedMarketOrder().options, clOrdId: 'cli-5' },
+    });
+
+    const first = core.buy(prepared);
+    const second = core.buy(prepared);
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    const [order1, order2] = await Promise.all([first, second]);
+    expect(order1).toBe(order2);
+
+    const third = await core.buy(prepared);
+    expect(third).toBe(order1);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  test('throws validation error for stop orders (not supported yet)', async () => {
+    const mockFetch = jest.fn();
+    global.fetch = mockFetch as unknown as typeof fetch;
+
+    const { core } = createHub();
+    const prepared: PreparedPlaceInput = {
+      symbol: 'XBTUSD',
+      side: 'sell',
+      size: 1,
+      type: 'Stop',
+      price: null,
+      stopPrice: 62_000,
+      options: {
+        postOnly: false,
+        reduceOnly: false,
+        timeInForce: null,
+        clOrdId: 'cli-stop',
+      },
+    };
+
+    await expect(core.sell(prepared)).rejects.toBeInstanceOf(ValidationError);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+});

--- a/tests/integration/rest/create-order.market.spec.ts
+++ b/tests/integration/rest/create-order.market.spec.ts
@@ -9,7 +9,9 @@ import type { PreparedPlaceInput } from '../../../src/infra/validation.js';
 
 const ORIGINAL_FETCH = global.fetch;
 
-function createPreparedMarketOrder(overrides: Partial<PreparedPlaceInput> = {}): PreparedPlaceInput {
+function createPreparedMarketOrder(
+  overrides: Partial<PreparedPlaceInput> = {},
+): PreparedPlaceInput {
   return {
     symbol: 'XBTUSD',
     side: 'buy',
@@ -40,24 +42,25 @@ describe('BitMEX REST createOrder – market', () => {
   });
 
   test('submits market payload and stores order snapshot', async () => {
-    const mockFetch = jest.fn(async () =>
-      new Response(
-        JSON.stringify({
-          orderID: 'ord-1',
-          clOrdID: 'cli-1',
-          symbol: 'XBTUSD',
-          side: 'Buy',
-          orderQty: 100,
-          ordType: 'Market',
-          ordStatus: 'New',
-          execType: 'New',
-          leavesQty: 100,
-          cumQty: 0,
-          avgPx: 0,
-          timestamp: '2024-01-01T00:00:00.000Z',
-        }),
-        { status: 200 },
-      ),
+    const mockFetch = jest.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            orderID: 'ord-1',
+            clOrdID: 'cli-1',
+            symbol: 'XBTUSD',
+            side: 'Buy',
+            orderQty: 100,
+            ordType: 'Market',
+            ordStatus: 'New',
+            execType: 'New',
+            leavesQty: 100,
+            cumQty: 0,
+            avgPx: 0,
+            timestamp: '2024-01-01T00:00:00.000Z',
+          }),
+          { status: 200 },
+        ),
     );
     global.fetch = mockFetch as unknown as typeof fetch;
 
@@ -163,11 +166,12 @@ describe('BitMEX REST createOrder – market', () => {
   });
 
   test('does not retry on 429', async () => {
-    const mockFetch = jest.fn(async () =>
-      new Response('Too many', {
-        status: 429,
-        headers: { 'Retry-After': '1' },
-      }),
+    const mockFetch = jest.fn(
+      async () =>
+        new Response('Too many', {
+          status: 429,
+          headers: { 'Retry-After': '1' },
+        }),
     );
     global.fetch = mockFetch as unknown as typeof fetch;
 


### PR DESCRIPTION
## Summary
- add a BitMEX REST createOrder helper that assembles payloads and applies retry logging
- map prepared orders to REST payloads, integrating buy/sell flows with inflight dedupe and REST upserts
- cover market/limit/post-only order scenarios plus retry and validation paths with integration tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd9a51e7b883209a79d807bfcdac45