### PR TITLE
feat(core): stop orders (stop-market; stop-limit behind flag)

### DIFF
--- a/src/core/bitmex/mappers/order.ts
+++ b/src/core/bitmex/mappers/order.ts
@@ -104,7 +104,9 @@ export function mapPreparedOrderToCreatePayload(input: PreparedPlaceInput): Crea
 
   if (input.type === 'Limit' || input.type === 'StopLimit') {
     if (input.price === null) {
-      throw new ValidationError('limit order requires price', { details: { type: input.type } });
+      throw new ValidationError('limit order requires price', {
+        details: { type: input.type },
+      });
     }
 
     payload.price = input.price;
@@ -112,7 +114,9 @@ export function mapPreparedOrderToCreatePayload(input: PreparedPlaceInput): Crea
 
   if (input.type === 'Stop' || input.type === 'StopLimit') {
     if (input.stopPrice === null || input.stopPrice === undefined) {
-      throw new ValidationError('stop order requires stop price', { details: { type: input.type } });
+      throw new ValidationError('stop order requires stop price', {
+        details: { type: input.type },
+      });
     }
 
     payload.stopPx = input.stopPrice;

--- a/src/core/bitmex/mappers/order.ts
+++ b/src/core/bitmex/mappers/order.ts
@@ -104,7 +104,12 @@ export function mapPreparedOrderToCreatePayload(input: PreparedPlaceInput): Crea
 
   if (input.type === 'Limit' || input.type === 'StopLimit') {
     if (input.price === null) {
-      throw new ValidationError('limit order requires price', {
+      const message =
+        input.type === 'StopLimit'
+          ? 'stop-limit order requires a limit price'
+          : 'limit order requires price';
+
+      throw new ValidationError(message, {
         details: { type: input.type },
       });
     }
@@ -120,12 +125,10 @@ export function mapPreparedOrderToCreatePayload(input: PreparedPlaceInput): Crea
     }
 
     payload.stopPx = input.stopPrice;
-  } else if (input.stopPrice !== null && input.stopPrice !== undefined) {
-    payload.stopPx = input.stopPrice;
   }
 
   const execInst: string[] = [];
-  if (input.options.postOnly) {
+  if (input.options.postOnly && input.type === 'Limit') {
     execInst.push('ParticipateDoNotInitiate');
   }
   if (input.options.reduceOnly) {

--- a/src/core/bitmex/rest/orders.ts
+++ b/src/core/bitmex/rest/orders.ts
@@ -9,7 +9,7 @@ export interface CreateOrderPayload {
   symbol: string;
   side: BitMexSide;
   orderQty: number;
-  ordType: Extract<BitMexOrderType, 'Market' | 'Limit' | 'Stop'>;
+  ordType: Extract<BitMexOrderType, 'Market' | 'Limit' | 'Stop' | 'StopLimit'>;
   clOrdID: string;
   price?: number;
   stopPx?: number;

--- a/src/domain/instrument.ts
+++ b/src/domain/instrument.ts
@@ -333,7 +333,7 @@ export class Instrument extends EventEmitter {
     const bestBid = book.bestBid?.price ?? undefined;
     const bestAsk = book.bestAsk?.price ?? undefined;
 
-    const type = inferOrderType(side, price, bestBid, bestAsk);
+    const type = inferOrderType(side, price, bestBid, bestAsk, opts);
     const validated = validatePlaceInput({
       symbol: this.symbolNative,
       side,
@@ -341,6 +341,8 @@ export class Instrument extends EventEmitter {
       price,
       type,
       opts,
+      bestBid,
+      bestAsk,
     });
 
     const clOrdId = validated.options.clOrdId ?? genClOrdID();

--- a/tests/integration/trading/stop-limit.flagged.spec.ts
+++ b/tests/integration/trading/stop-limit.flagged.spec.ts
@@ -65,29 +65,29 @@ describe('BitMEX trading – stop-limit orders', () => {
       .build();
 
     const harness = await setupPrivateHarness(scenario, { startTime: '2024-01-01T00:02:00.000Z' });
-    const { hub, core, clock, server, cleanup } = harness;
+    const { core, clock, server, cleanup } = harness;
 
     try {
       const fetchMock = jest.fn(
-      async () =>
-        new Response(
-          JSON.stringify({
-            orderID: 'ws-stop-limit-1',
-            clOrdID,
-            symbol: 'XBTUSD',
-            side: 'Sell',
-            orderQty: 5,
-            ordType: 'StopLimit',
-            stopPx: stopPrice,
-            price: limitPrice,
-            ordStatus: 'New',
-            execType: 'New',
-            leavesQty: 5,
-            cumQty: 0,
-            timestamp: '2024-01-01T00:02:00.050Z',
-          }),
-          { status: 200 },
-        ),
+        async () =>
+          new Response(
+            JSON.stringify({
+              orderID: 'ws-stop-limit-1',
+              clOrdID,
+              symbol: 'XBTUSD',
+              side: 'Sell',
+              orderQty: 5,
+              ordType: 'StopLimit',
+              stopPx: stopPrice,
+              price: limitPrice,
+              ordStatus: 'New',
+              execType: 'New',
+              leavesQty: 5,
+              cumQty: 0,
+              timestamp: '2024-01-01T00:02:00.050Z',
+            }),
+            { status: 200 },
+          ),
       );
       global.fetch = fetchMock as unknown as typeof fetch;
 
@@ -139,8 +139,6 @@ describe('BitMEX trading – stop-limit orders', () => {
     instrument.orderBook.bestBid = { price: 50_000, size: 1 };
     instrument.orderBook.bestAsk = { price: 50_010, size: 1 };
 
-    expect(() =>
-      instrument.sell(2, 50_050, { stopLimitPrice: 50_040 }),
-    ).toThrow(ValidationError);
+    expect(() => instrument.sell(2, 50_050, { stopLimitPrice: 50_040 })).toThrow(ValidationError);
   });
 });

--- a/tests/integration/trading/stop-limit.flagged.spec.ts
+++ b/tests/integration/trading/stop-limit.flagged.spec.ts
@@ -1,0 +1,146 @@
+import { jest } from '@jest/globals';
+
+import { Instrument } from '../../../src/domain/instrument.js';
+import { OrderStatus } from '../../../src/domain/order.js';
+import { ValidationError } from '../../../src/infra/errors.js';
+
+import { createScenario } from '../../helpers/ws-mock/scenario.js';
+import { setupPrivateHarness } from '../../helpers/privateHarness.js';
+
+const ORIGINAL_FETCH = global.fetch;
+
+describe('BitMEX trading – stop-limit orders', () => {
+  afterEach(() => {
+    global.fetch = ORIGINAL_FETCH;
+    jest.restoreAllMocks();
+  });
+
+  test('submits stop-limit payload when flag is provided', async () => {
+    const clOrdID = 'stop-limit-1';
+    const stopPrice = 49_950;
+    const limitPrice = 49_940;
+
+    const scenario = createScenario()
+      .open()
+      .requireAuth()
+      .expectAuth()
+      .expectSubscribe(['wallet', 'position', 'order'])
+      .sendSubscribeAck(['wallet', 'position', 'order'])
+      .sendPartial('order', [])
+      .delay(40)
+      .sendInsert('order', [
+        {
+          orderID: 'ws-stop-limit-1',
+          clOrdID,
+          symbol: 'XBTUSD',
+          side: 'Sell',
+          orderQty: 5,
+          ordType: 'StopLimit',
+          stopPx: stopPrice,
+          price: limitPrice,
+          ordStatus: 'New',
+          execType: 'New',
+          leavesQty: 5,
+          cumQty: 0,
+          timestamp: '2024-01-01T00:02:00.000Z',
+        },
+      ])
+      .delay(60)
+      .sendUpdate('order', [
+        {
+          orderID: 'ws-stop-limit-1',
+          symbol: 'XBTUSD',
+          leavesQty: 0,
+          cumQty: 5,
+          avgPx: 49_930,
+          ordStatus: 'Filled',
+          execType: 'Trade',
+          lastQty: 5,
+          lastPx: 49_930,
+          stopPx: stopPrice,
+          price: limitPrice,
+          transactTime: '2024-01-01T00:02:00.120Z',
+        },
+      ])
+      .build();
+
+    const harness = await setupPrivateHarness(scenario, { startTime: '2024-01-01T00:02:00.000Z' });
+    const { hub, core, clock, server, cleanup } = harness;
+
+    try {
+      const fetchMock = jest.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            orderID: 'ws-stop-limit-1',
+            clOrdID,
+            symbol: 'XBTUSD',
+            side: 'Sell',
+            orderQty: 5,
+            ordType: 'StopLimit',
+            stopPx: stopPrice,
+            price: limitPrice,
+            ordStatus: 'New',
+            execType: 'New',
+            leavesQty: 5,
+            cumQty: 0,
+            timestamp: '2024-01-01T00:02:00.050Z',
+          }),
+          { status: 200 },
+        ),
+      );
+      global.fetch = fetchMock as unknown as typeof fetch;
+
+      const instrument = new Instrument(
+        { symbolNative: 'XBTUSD', symbolUni: 'XBTUSD' },
+        { tradeBufferSize: 10 },
+      );
+      instrument.orderBook.bestBid = { price: 50_000, size: 1 };
+      instrument.orderBook.bestAsk = { price: 50_010, size: 1 };
+
+      const prepared = instrument.sell(5, stopPrice, { clOrdID, stopLimitPrice: limitPrice });
+      expect(prepared.type).toBe('StopLimit');
+
+      const orderPromise = core.sell(prepared);
+
+      await clock.waitFor(() => fetchMock.mock.calls.length === 1);
+
+      const [, init] = fetchMock.mock.calls[0] as [RequestInfo | URL, RequestInit];
+      const body = JSON.parse(String(init.body));
+      expect(body).toMatchObject({
+        symbol: 'XBTUSD',
+        side: 'Sell',
+        orderQty: 5,
+        ordType: 'StopLimit',
+        stopPx: stopPrice,
+        price: limitPrice,
+        clOrdID,
+      });
+
+      await server.waitForCompletion();
+      await clock.wait(0);
+
+      const order = await orderPromise;
+      const snapshot = order.getSnapshot();
+      expect(snapshot.status).toBe(OrderStatus.Filled);
+      expect(snapshot.stopPrice).toBe(stopPrice);
+      expect(snapshot.price).toBe(limitPrice);
+      expect(snapshot.type).toBe('StopLimit');
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test('throws when stop-limit price crosses the top of book', () => {
+    const instrument = new Instrument(
+      { symbolNative: 'XBTUSD', symbolUni: 'XBTUSD' },
+      { tradeBufferSize: 10 },
+    );
+    instrument.orderBook.bestBid = { price: 50_000, size: 1 };
+    instrument.orderBook.bestAsk = { price: 50_010, size: 1 };
+
+    expect(() =>
+      instrument.sell(2, 50_050, { stopLimitPrice: 50_040 }),
+    ).toThrow(ValidationError);
+  });
+});

--- a/tests/integration/trading/stop-market.lifecycle.spec.ts
+++ b/tests/integration/trading/stop-market.lifecycle.spec.ts
@@ -1,0 +1,240 @@
+import { jest } from '@jest/globals';
+
+import { Instrument } from '../../../src/domain/instrument.js';
+import { OrderStatus } from '../../../src/domain/order.js';
+
+import { createScenario } from '../../helpers/ws-mock/scenario.js';
+import { setupPrivateHarness } from '../../helpers/privateHarness.js';
+
+const ORIGINAL_FETCH = global.fetch;
+
+describe('BitMEX trading – stop-market lifecycle', () => {
+  afterEach(() => {
+    global.fetch = ORIGINAL_FETCH;
+    jest.restoreAllMocks();
+  });
+
+  test('submits stop-market payload and handles fill lifecycle', async () => {
+    const clOrdID = 'stop-life-1';
+    const stopPrice = 50_050;
+
+    const scenario = createScenario()
+      .open()
+      .requireAuth()
+      .expectAuth()
+      .expectSubscribe(['wallet', 'position', 'order'])
+      .sendSubscribeAck(['wallet', 'position', 'order'])
+      .sendPartial('order', [])
+      .delay(50)
+      .sendInsert('order', [
+        {
+          orderID: 'ws-stop-life-1',
+          clOrdID,
+          symbol: 'XBTUSD',
+          side: 'Buy',
+          orderQty: 10,
+          ordType: 'Stop',
+          stopPx: stopPrice,
+          ordStatus: 'New',
+          execType: 'New',
+          leavesQty: 10,
+          cumQty: 0,
+          timestamp: '2024-01-01T00:00:01.000Z',
+        },
+      ])
+      .delay(100)
+      .sendUpdate('order', [
+        {
+          orderID: 'ws-stop-life-1',
+          symbol: 'XBTUSD',
+          leavesQty: 0,
+          cumQty: 10,
+          avgPx: 50_055,
+          ordStatus: 'Filled',
+          execType: 'Trade',
+          lastQty: 10,
+          lastPx: 50_055,
+          stopPx: stopPrice,
+          transactTime: '2024-01-01T00:00:02.000Z',
+        },
+      ])
+      .build();
+
+    const harness = await setupPrivateHarness(scenario, { startTime: '2024-01-01T00:00:00.000Z' });
+    const { hub, core, clock, server, cleanup } = harness;
+
+    try {
+      const fetchMock = jest.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            orderID: 'ws-stop-life-1',
+            clOrdID,
+            symbol: 'XBTUSD',
+            side: 'Buy',
+            orderQty: 10,
+            ordType: 'Stop',
+            stopPx: stopPrice,
+            ordStatus: 'New',
+            execType: 'New',
+            leavesQty: 10,
+            cumQty: 0,
+            timestamp: '2024-01-01T00:00:01.500Z',
+          }),
+          { status: 200 },
+        ),
+      );
+      global.fetch = fetchMock as unknown as typeof fetch;
+
+      const instrument = new Instrument(
+        { symbolNative: 'XBTUSD', symbolUni: 'XBTUSD' },
+        { tradeBufferSize: 10 },
+      );
+      instrument.orderBook.bestBid = { price: 50_000, size: 1 };
+      instrument.orderBook.bestAsk = { price: 50_010, size: 1 };
+
+      const prepared = instrument.buy(10, stopPrice, { clOrdID });
+      expect(prepared.type).toBe('Stop');
+
+      const orderPromise = core.buy(prepared);
+
+      await clock.waitFor(() => fetchMock.mock.calls.length === 1);
+
+      const [, init] = fetchMock.mock.calls[0] as [RequestInfo | URL, RequestInit];
+      const body = JSON.parse(String(init.body));
+      expect(body).toMatchObject({
+        symbol: 'XBTUSD',
+        side: 'Buy',
+        orderQty: 10,
+        ordType: 'Stop',
+        stopPx: stopPrice,
+        clOrdID,
+      });
+      expect(body).not.toHaveProperty('price');
+
+      await server.waitForCompletion();
+      await clock.wait(0);
+
+      const stored = hub.orders.getByClOrdId(clOrdID);
+      expect(stored?.status).toBe(OrderStatus.Filled);
+
+      const order = await orderPromise;
+      const snapshot = order.getSnapshot();
+      expect(snapshot.status).toBe(OrderStatus.Filled);
+      expect(snapshot.stopPrice).toBe(stopPrice);
+      expect(snapshot.type).toBe('Stop');
+      expect(hub.orders.getInflightByClOrdId(clOrdID)).toBeUndefined();
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test('merges private updates arriving before REST response', async () => {
+    const clOrdID = 'stop-race-1';
+    const stopPrice = 49_980;
+
+    const scenario = createScenario()
+      .open()
+      .requireAuth()
+      .expectAuth()
+      .expectSubscribe(['wallet', 'position', 'order'])
+      .sendSubscribeAck(['wallet', 'position', 'order'])
+      .sendPartial('order', [])
+      .delay(20)
+      .sendInsert('order', [
+        {
+          orderID: 'ws-stop-race-1',
+          clOrdID,
+          symbol: 'XBTUSD',
+          side: 'Buy',
+          orderQty: 7,
+          ordType: 'Stop',
+          stopPx: stopPrice,
+          ordStatus: 'New',
+          execType: 'New',
+          leavesQty: 7,
+          cumQty: 0,
+          timestamp: '2024-01-01T00:01:00.000Z',
+        },
+      ])
+      .delay(40)
+      .sendUpdate('order', [
+        {
+          orderID: 'ws-stop-race-1',
+          symbol: 'XBTUSD',
+          leavesQty: 0,
+          cumQty: 7,
+          avgPx: 49_990,
+          ordStatus: 'Filled',
+          execType: 'Trade',
+          lastQty: 7,
+          lastPx: 49_990,
+          stopPx: stopPrice,
+          transactTime: '2024-01-01T00:01:00.080Z',
+        },
+      ])
+      .build();
+
+    const harness = await setupPrivateHarness(scenario, { startTime: '2024-01-01T00:01:00.000Z' });
+    const { hub, core, clock, server, cleanup } = harness;
+
+    try {
+      let resolveFetch: ((value: Response) => void) | undefined;
+      const fetchMock = jest.fn(
+        () =>
+          new Promise<Response>((resolve) => {
+            resolveFetch = resolve;
+          }),
+      );
+      global.fetch = fetchMock as unknown as typeof fetch;
+
+      const instrument = new Instrument(
+        { symbolNative: 'XBTUSD', symbolUni: 'XBTUSD' },
+        { tradeBufferSize: 10 },
+      );
+      instrument.orderBook.bestBid = { price: 49_950, size: 1 };
+      instrument.orderBook.bestAsk = { price: 49_970, size: 1 };
+
+      const prepared = instrument.buy(7, stopPrice, { clOrdID });
+      expect(prepared.type).toBe('Stop');
+
+      const orderPromise = core.buy(prepared);
+
+      await server.waitForCompletion();
+      await clock.wait(0);
+
+      const interim = hub.orders.getByClOrdId(clOrdID);
+      expect(interim).toBeDefined();
+      expect(interim!.getSnapshot().status).toBe(OrderStatus.Filled);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+
+      resolveFetch!(
+        new Response(
+          JSON.stringify({
+            orderID: 'ws-stop-race-1',
+            clOrdID,
+            symbol: 'XBTUSD',
+            side: 'Buy',
+            orderQty: 7,
+            ordType: 'Stop',
+            stopPx: stopPrice,
+            ordStatus: 'Filled',
+            execType: 'Trade',
+            leavesQty: 0,
+            cumQty: 7,
+            avgPx: 49_990,
+            timestamp: '2024-01-01T00:01:00.150Z',
+          }),
+          { status: 200 },
+        ),
+      );
+
+      const order = await orderPromise;
+      expect(order).toBe(interim);
+      expect(order.getSnapshot().status).toBe(OrderStatus.Filled);
+      expect(hub.orders.getInflightByClOrdId(clOrdID)).toBeUndefined();
+    } finally {
+      await cleanup();
+    }
+  });
+});

--- a/tests/integration/trading/stop-market.lifecycle.spec.ts
+++ b/tests/integration/trading/stop-market.lifecycle.spec.ts
@@ -65,24 +65,24 @@ describe('BitMEX trading – stop-market lifecycle', () => {
 
     try {
       const fetchMock = jest.fn(
-      async () =>
-        new Response(
-          JSON.stringify({
-            orderID: 'ws-stop-life-1',
-            clOrdID,
-            symbol: 'XBTUSD',
-            side: 'Buy',
-            orderQty: 10,
-            ordType: 'Stop',
-            stopPx: stopPrice,
-            ordStatus: 'New',
-            execType: 'New',
-            leavesQty: 10,
-            cumQty: 0,
-            timestamp: '2024-01-01T00:00:01.500Z',
-          }),
-          { status: 200 },
-        ),
+        async () =>
+          new Response(
+            JSON.stringify({
+              orderID: 'ws-stop-life-1',
+              clOrdID,
+              symbol: 'XBTUSD',
+              side: 'Buy',
+              orderQty: 10,
+              ordType: 'Stop',
+              stopPx: stopPrice,
+              ordStatus: 'New',
+              execType: 'New',
+              leavesQty: 10,
+              cumQty: 0,
+              timestamp: '2024-01-01T00:00:01.500Z',
+            }),
+            { status: 200 },
+          ),
       );
       global.fetch = fetchMock as unknown as typeof fetch;
 

--- a/tests/unit/core/mappers/order-payload.spec.ts
+++ b/tests/unit/core/mappers/order-payload.spec.ts
@@ -1,0 +1,111 @@
+import { mapPreparedOrderToCreatePayload } from '../../../../src/core/bitmex/mappers/order.js';
+import { ValidationError } from '../../../../src/infra/errors.js';
+
+import type { PreparedPlaceInput } from '../../../../src/infra/validation.js';
+
+function makeInput(overrides: Partial<PreparedPlaceInput> = {}): PreparedPlaceInput {
+  const base: PreparedPlaceInput = {
+    symbol: 'XBTUSD',
+    side: 'buy',
+    size: 1,
+    type: 'Limit',
+    price: 50_000,
+    stopPrice: null,
+    options: {
+      postOnly: false,
+      reduceOnly: false,
+      timeInForce: null,
+      stopLimitPrice: null,
+      clOrdId: 'client-order-1',
+    },
+  };
+
+  return {
+    ...base,
+    ...overrides,
+    options: {
+      ...base.options,
+      ...(overrides.options ?? {}),
+      clOrdId: overrides.options?.clOrdId ?? base.options.clOrdId,
+    },
+  };
+}
+
+describe('mapPreparedOrderToCreatePayload', () => {
+  test('maps stop order to stop payload without price', () => {
+    const input = makeInput({
+      type: 'Stop',
+      price: null,
+      stopPrice: 50_050,
+    });
+
+    const payload = mapPreparedOrderToCreatePayload(input);
+
+    expect(payload).toEqual({
+      symbol: 'XBTUSD',
+      side: 'Buy',
+      orderQty: 1,
+      ordType: 'Stop',
+      clOrdID: 'client-order-1',
+      stopPx: 50_050,
+    });
+    expect(payload).not.toHaveProperty('price');
+  });
+
+  test('maps stop-limit order with both stop and limit prices', () => {
+    const input = makeInput({
+      type: 'StopLimit',
+      price: 49_990,
+      stopPrice: 50_000,
+      options: { stopLimitPrice: 49_990 },
+    });
+
+    const payload = mapPreparedOrderToCreatePayload(input);
+
+    expect(payload).toEqual({
+      symbol: 'XBTUSD',
+      side: 'Buy',
+      orderQty: 1,
+      ordType: 'StopLimit',
+      clOrdID: 'client-order-1',
+      price: 49_990,
+      stopPx: 50_000,
+    });
+  });
+
+  test('includes exec instructions and time in force when provided', () => {
+    const input = makeInput({
+      options: {
+        postOnly: true,
+        reduceOnly: true,
+        timeInForce: 'GoodTillCancel',
+      },
+    });
+
+    const payload = mapPreparedOrderToCreatePayload(input);
+
+    expect(payload.execInst).toBe('ParticipateDoNotInitiate,ReduceOnly');
+    expect(payload.timeInForce).toBe('GoodTillCancel');
+  });
+
+  test('throws when limit price is missing for stop-limit orders', () => {
+    const input = makeInput({
+      type: 'StopLimit',
+      price: null,
+      stopPrice: 50_000,
+      options: { stopLimitPrice: null },
+    });
+
+    expect(() => mapPreparedOrderToCreatePayload(input)).toThrow(ValidationError);
+  });
+
+  test('throws when stop price is missing for stop orders', () => {
+    const input = makeInput({
+      type: 'Stop',
+      price: null,
+      stopPrice: null,
+    });
+
+    expect(() => mapPreparedOrderToCreatePayload(input)).toThrow(ValidationError);
+  });
+});

--- a/tests/unit/core/mappers/order-type.spec.ts
+++ b/tests/unit/core/mappers/order-type.spec.ts
@@ -6,27 +6,28 @@ describe('inferOrderType', () => {
     expect(inferOrderType('sell', null, 100, 105)).toBe('Market');
   });
 
-  test('classifies buy limit zone at or below best ask', () => {
+  test('classifies buy limit zone below best ask', () => {
     expect(inferOrderType('buy', 100, 95, 105)).toBe('Limit');
     expect(inferOrderType('buy', 104, 95, 105)).toBe('Limit');
   });
 
-  test('treats equality with best ask or bid as limit', () => {
-    expect(inferOrderType('buy', 105, 95, 105)).toBe('Limit');
-    expect(inferOrderType('sell', 100, 100, 110)).toBe('Limit');
+  test('treats equality with best ask or bid as stop', () => {
+    expect(inferOrderType('buy', 105, 95, 105)).toBe('Stop');
+    expect(inferOrderType('sell', 100, 100, 110)).toBe('Stop');
   });
 
-  test('classifies buy stop zone above best ask', () => {
+  test('classifies buy stop zone at or above best ask', () => {
     expect(inferOrderType('buy', 106, 95, 105)).toBe('Stop');
     expect(inferOrderType('buy', 120, undefined, 110)).toBe('Stop');
   });
 
-  test('classifies sell limit zone at or above best bid', () => {
+  test('classifies sell limit zone above best bid', () => {
     expect(inferOrderType('sell', 105, 100, 110)).toBe('Limit');
     expect(inferOrderType('sell', 101, 100, 110)).toBe('Limit');
   });
 
-  test('classifies sell stop zone below best bid', () => {
+  test('classifies sell stop zone at or below best bid', () => {
+    expect(inferOrderType('sell', 100, 100, 110)).toBe('Stop');
     expect(inferOrderType('sell', 98, 100, 110)).toBe('Stop');
     expect(inferOrderType('sell', 50, 60, undefined)).toBe('Stop');
   });
@@ -39,5 +40,19 @@ describe('inferOrderType', () => {
   test('falls back to limit when only one side of the book is known', () => {
     expect(inferOrderType('buy', 10, 8, undefined)).toBe('Limit');
     expect(inferOrderType('sell', 12, undefined, 13)).toBe('Limit');
+  });
+
+  test('returns StopLimit when stopLimitPrice option is provided', () => {
+    expect(inferOrderType('buy', 110, 100, 105, { stopLimitPrice: 111 })).toBe('StopLimit');
+    expect(inferOrderType('sell', 90, 95, 100, { stopLimitPrice: 89 })).toBe('StopLimit');
+  });
+
+  test('prefers StopLimit option even without book context', () => {
+    expect(inferOrderType('buy', 120, undefined, undefined, { stopLimitPrice: 121 })).toBe(
+      'StopLimit',
+    );
+    expect(inferOrderType('sell', 80, undefined, undefined, { stopLimitPrice: 79 })).toBe(
+      'StopLimit',
+    );
   });
 });


### PR DESCRIPTION
## Summary
- support stop-market and stop-limit requests by extending BitMEX order inference and REST payload mapping
- tighten place-order validation with stop-limit options, stop price zone checks, and updated normalization
- add unit and integration coverage for stop-market life cycles, stop-limit flag behavior, and race handling

## Testing
- npm test -- tests/unit/infra/validation/place-input.spec.ts tests/unit/core/mappers/order-type.spec.ts tests/integration/trading/stop-market.lifecycle.spec.ts tests/integration/trading/stop-limit.flagged.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68ce45a23f608320aedbccbb54f7e599