### PR TITLE
feat(bitmex): stop orders (stop-market; stop-limit behind flag)

### DIFF
--- a/src/core/bitmex/rest/orders.ts
+++ b/src/core/bitmex/rest/orders.ts
@@ -9,7 +9,7 @@ export interface CreateOrderPayload {
   symbol: string;
   side: BitMexSide;
   orderQty: number;
-  ordType: Extract<BitMexOrderType, 'Market' | 'Limit' | 'Stop'>;
+  ordType: Extract<BitMexOrderType, 'Market' | 'Limit' | 'Stop' | 'StopLimit'>;
   clOrdID: string;
   price?: number;
   stopPx?: number;

--- a/tests/integration/trading/stop-limit.flagged.spec.ts
+++ b/tests/integration/trading/stop-limit.flagged.spec.ts
@@ -1,0 +1,99 @@
+import { jest } from '@jest/globals';
+
+import { ExchangeHub } from '../../../src/ExchangeHub.js';
+import { OrderStatus } from '../../../src/domain/order.js';
+
+import type { BitMex } from '../../../src/core/bitmex/index.js';
+import type { PreparedPlaceInput } from '../../../src/infra/validation.js';
+
+const ORIGINAL_FETCH = global.fetch;
+
+function createPreparedStopLimitOrder(
+  overrides: Partial<PreparedPlaceInput> = {},
+): PreparedPlaceInput {
+  const base: PreparedPlaceInput = {
+    symbol: 'XBTUSD',
+    side: 'buy',
+    size: 25,
+    type: 'StopLimit',
+    price: 50_150,
+    stopPrice: 50_200,
+    options: {
+      postOnly: false,
+      reduceOnly: false,
+      timeInForce: null,
+      clOrdId: 'stop-limit-cli-1',
+    },
+  };
+
+  return {
+    ...base,
+    ...overrides,
+    options: { ...base.options, ...overrides.options },
+  };
+}
+
+function createHub() {
+  const hub = new ExchangeHub('BitMex', { isTest: true, apiKey: 'key', apiSec: 'secret' });
+  const core = hub.Core as BitMex;
+  return { hub, core };
+}
+
+describe('BitMEX trading – stop-limit flag', () => {
+  afterEach(() => {
+    global.fetch = ORIGINAL_FETCH;
+    jest.restoreAllMocks();
+  });
+
+  test('submits stop-limit payload with both trigger and limit prices', async () => {
+    const mockFetch = jest.fn(async () =>
+      new Response(
+        JSON.stringify({
+          orderID: 'stop-limit-ord-1',
+          clOrdID: 'stop-limit-cli-1',
+          symbol: 'XBTUSD',
+          side: 'Buy',
+          orderQty: 25,
+          ordType: 'StopLimit',
+          ordStatus: 'New',
+          execType: 'New',
+          price: 50_150,
+          stopPx: 50_200,
+          leavesQty: 25,
+          cumQty: 0,
+          avgPx: 0,
+          timestamp: '2024-01-01T00:00:05.000Z',
+        }),
+        { status: 200 },
+      ),
+    );
+
+    global.fetch = mockFetch as unknown as typeof fetch;
+
+    const { hub, core } = createHub();
+    const prepared = createPreparedStopLimitOrder();
+
+    const order = await core.buy(prepared);
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [, init] = mockFetch.mock.calls[0] as [RequestInfo | URL, RequestInit];
+    const body = JSON.parse(String(init.body));
+    expect(body).toMatchObject({
+      symbol: 'XBTUSD',
+      side: 'Buy',
+      ordType: 'StopLimit',
+      price: 50_150,
+      stopPx: 50_200,
+      clOrdID: 'stop-limit-cli-1',
+    });
+
+    const snapshot = order.getSnapshot();
+    expect(snapshot.type).toBe('StopLimit');
+    expect(snapshot.price).toBe(50_150);
+    expect(snapshot.stopPrice).toBe(50_200);
+    expect(snapshot.status).toBe(OrderStatus.Placed);
+
+    expect(hub.orders.getByClOrdId('stop-limit-cli-1')).toBe(order);
+    expect(hub.orders.getInflightByClOrdId('stop-limit-cli-1')).toBeUndefined();
+  });
+});

--- a/tests/integration/trading/stop-market.lifecycle.spec.ts
+++ b/tests/integration/trading/stop-market.lifecycle.spec.ts
@@ -1,0 +1,178 @@
+import { jest } from '@jest/globals';
+
+import { OrderStatus } from '../../../src/domain/order.js';
+
+import type { PreparedPlaceInput } from '../../../src/infra/validation.js';
+
+import { createScenario } from '../../helpers/ws-mock/scenario.js';
+import { setupPrivateHarness } from '../../helpers/privateHarness.js';
+
+const ORIGINAL_FETCH = global.fetch;
+
+function createPreparedStopOrder(
+  overrides: Partial<PreparedPlaceInput> = {},
+): PreparedPlaceInput {
+  const base: PreparedPlaceInput = {
+    symbol: 'XBTUSD',
+    side: 'buy',
+    size: 75,
+    type: 'Stop',
+    price: null,
+    stopPrice: 50_200,
+    options: {
+      postOnly: false,
+      reduceOnly: false,
+      timeInForce: null,
+      clOrdId: 'stop-cli-1',
+    },
+  };
+
+  return {
+    ...base,
+    ...overrides,
+    options: { ...base.options, ...overrides.options },
+  };
+}
+
+describe('BitMEX trading – stop-market lifecycle', () => {
+  afterEach(() => {
+    global.fetch = ORIGINAL_FETCH;
+    jest.restoreAllMocks();
+  });
+
+  test('handles stop order trigger and fill even when WS races REST response', async () => {
+    const scenario = createScenario()
+      .open()
+      .requireAuth()
+      .expectAuth()
+      .expectSubscribe(['wallet', 'position', 'order'])
+      .sendSubscribeAck(['wallet', 'position', 'order'])
+      .sendPartial('order', [])
+      .delay(50)
+      .sendInsert('order', [
+        {
+          orderID: 'stop-ord-1',
+          clOrdID: 'stop-cli-1',
+          symbol: 'XBTUSD',
+          side: 'Buy',
+          orderQty: 75,
+          ordType: 'Stop',
+          ordStatus: 'New',
+          execType: 'New',
+          stopPx: 50_200,
+          leavesQty: 75,
+          cumQty: 0,
+          avgPx: 0,
+          timestamp: '2024-01-01T00:00:01.000Z',
+        },
+      ])
+      .delay(50)
+      .sendUpdate('order', [
+        {
+          orderID: 'stop-ord-1',
+          clOrdID: 'stop-cli-1',
+          symbol: 'XBTUSD',
+          ordStatus: 'Triggered',
+          execType: 'Calculated',
+          stopPx: 50_200,
+          leavesQty: 75,
+          cumQty: 0,
+          timestamp: '2024-01-01T00:00:02.000Z',
+        },
+      ])
+      .delay(50)
+      .sendUpdate('order', [
+        {
+          orderID: 'stop-ord-1',
+          symbol: 'XBTUSD',
+          side: 'Buy',
+          orderQty: 75,
+          ordStatus: 'Filled',
+          execType: 'Trade',
+          stopPx: 50_200,
+          leavesQty: 0,
+          cumQty: 75,
+          avgPx: 50_250,
+          lastQty: 75,
+          lastPx: 50_250,
+          transactTime: '2024-01-01T00:00:03.000Z',
+        },
+      ])
+      .build();
+
+    const harness = await setupPrivateHarness(scenario, {
+      startTime: '2024-01-01T00:00:00.000Z',
+    });
+    const { clock, hub, core, server } = harness;
+
+    const mockFetch = jest.fn(
+      () =>
+        new Promise<Response>((resolve) => {
+          setTimeout(() => {
+            resolve(
+              new Response(
+                JSON.stringify({
+                  orderID: 'stop-ord-1',
+                  clOrdID: 'stop-cli-1',
+                  symbol: 'XBTUSD',
+                  side: 'Buy',
+                  orderQty: 75,
+                  ordType: 'Stop',
+                  ordStatus: 'New',
+                  execType: 'New',
+                  stopPx: 50_200,
+                  leavesQty: 75,
+                  cumQty: 0,
+                  avgPx: 0,
+                  timestamp: '2024-01-01T00:00:01.500Z',
+                }),
+                { status: 200 },
+              ),
+            );
+          }, 200);
+        }),
+    );
+
+    global.fetch = mockFetch as unknown as typeof fetch;
+
+    const prepared = createPreparedStopOrder();
+    const orderPromise = core.buy(prepared);
+
+    expect(hub.orders.getInflightByClOrdId('stop-cli-1')).toBeDefined();
+
+    await clock.waitFor(() => hub.orders.getByClOrdId('stop-cli-1') !== undefined);
+    const interim = hub.orders.getByClOrdId('stop-cli-1');
+    expect(interim).toBeDefined();
+    expect(interim!.getSnapshot().status).toBe(OrderStatus.Placed);
+
+    await clock.waitFor(
+      () => hub.orders.getByClOrdId('stop-cli-1')?.getSnapshot().status === OrderStatus.Filled,
+    );
+
+    await clock.wait(200);
+    const order = await orderPromise;
+    expect(order).toBe(interim);
+
+    const snapshot = order.getSnapshot();
+    expect(snapshot.status).toBe(OrderStatus.Filled);
+    expect(snapshot.filledQty).toBe(75);
+    expect(snapshot.stopPrice).toBe(50_200);
+    expect(snapshot.avgFillPrice).toBeCloseTo(50_250, 6);
+
+    expect(hub.orders.getInflightByClOrdId('stop-cli-1')).toBeUndefined();
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [, init] = mockFetch.mock.calls[0] as [RequestInfo | URL, RequestInit];
+    const body = JSON.parse(String(init.body));
+    expect(body).toMatchObject({
+      ordType: 'Stop',
+      stopPx: 50_200,
+      clOrdID: 'stop-cli-1',
+    });
+    expect(body).not.toHaveProperty('price');
+
+    await server.waitForCompletion();
+    await clock.wait(10);
+    await harness.cleanup();
+  });
+});

--- a/tests/unit/core/mappers/order-payload.spec.ts
+++ b/tests/unit/core/mappers/order-payload.spec.ts
@@ -64,4 +64,43 @@ describe('mapPreparedOrderToCreatePayload', () => {
       new ValidationError('unsupported timeInForce'),
     );
   });
+
+  test('maps stop orders to stop ordType with stopPx only', () => {
+    const input = createPreparedInput({
+      type: 'Stop',
+      price: null,
+      stopPrice: 50_500,
+    });
+
+    const payload = mapPreparedOrderToCreatePayload(input);
+    expect(payload).toMatchObject({ ordType: 'Stop', stopPx: 50_500 });
+    expect(payload).not.toHaveProperty('price');
+  });
+
+  test('maps stop-limit orders with both price and stopPx', () => {
+    const input = createPreparedInput({
+      type: 'StopLimit',
+      price: 50_450,
+      stopPrice: 50_500,
+    });
+
+    const payload = mapPreparedOrderToCreatePayload(input);
+    expect(payload).toMatchObject({ ordType: 'StopLimit', price: 50_450, stopPx: 50_500 });
+  });
+
+  test('throws when stop order is missing stop price', () => {
+    const input = createPreparedInput({ type: 'Stop', price: null, stopPrice: null });
+
+    expect(() => mapPreparedOrderToCreatePayload(input)).toThrowError(
+      new ValidationError('stop order requires stop price'),
+    );
+  });
+
+  test('throws when stop-limit payload misses limit price', () => {
+    const input = createPreparedInput({ type: 'StopLimit', price: null, stopPrice: 50_400 });
+
+    expect(() => mapPreparedOrderToCreatePayload(input)).toThrowError(
+      new ValidationError('stop-limit order requires limit price'),
+    );
+  });
 });

--- a/tests/unit/core/mappers/order-type.spec.ts
+++ b/tests/unit/core/mappers/order-type.spec.ts
@@ -40,4 +40,10 @@ describe('inferOrderType', () => {
     expect(inferOrderType('buy', 10, 8, undefined)).toBe('Limit');
     expect(inferOrderType('sell', 12, undefined, 13)).toBe('Limit');
   });
+
+  test('prefers stop-limit classification when explicit limit price is provided', () => {
+    expect(inferOrderType('buy', 110, 100, 105, 109)).toBe('StopLimit');
+    expect(inferOrderType('sell', 90, 95, 100, 89)).toBe('StopLimit');
+    expect(inferOrderType('buy', 125, undefined, undefined, 120)).toBe('StopLimit');
+  });
 });

--- a/tests/unit/domain/instrument-place.spec.ts
+++ b/tests/unit/domain/instrument-place.spec.ts
@@ -1,0 +1,52 @@
+import { Instrument } from '../../../src/domain/instrument.js';
+import { ValidationError } from '../../../src/infra/errors.js';
+
+function createInstrument(): Instrument {
+  return new Instrument({ symbolNative: 'XBTUSD', symbolUni: 'XBTUSD' });
+}
+
+describe('Instrument place preparation', () => {
+  test('rejects buy stop orders with trigger below best ask', () => {
+    const instrument = createInstrument();
+    instrument.orderBook.reset([
+      { id: 1, side: 'buy', price: 49_900, size: 10 },
+      { id: 2, side: 'sell', price: 50_000, size: 10 },
+    ]);
+
+    expect(() => instrument.buy(1, 49_950, { stopLimitPrice: 49_940 })).toThrow(
+      ValidationError,
+    );
+  });
+
+  test('rejects sell stop orders with trigger above best bid', () => {
+    const instrument = createInstrument();
+    instrument.orderBook.reset([
+      { id: 1, side: 'buy', price: 49_900, size: 5 },
+      { id: 2, side: 'sell', price: 50_000, size: 5 },
+    ]);
+
+    expect(() => instrument.sell(1, 49_950, { stopLimitPrice: 49_960 })).toThrow(
+      ValidationError,
+    );
+  });
+
+  test('accepts stop-limit orders within valid zone', () => {
+    const instrument = createInstrument();
+    instrument.orderBook.reset([
+      { id: 1, side: 'buy', price: 49_900, size: 5 },
+      { id: 2, side: 'sell', price: 50_000, size: 5 },
+    ]);
+
+    const prepared = instrument.buy(2, 50_050, { stopLimitPrice: 50_040, clOrdID: 'unit-stop' });
+
+    expect(prepared.type).toBe('StopLimit');
+    expect(prepared.stopPrice).toBe(50_050);
+    expect(prepared.price).toBe(50_040);
+  });
+
+  test('allows stop orders when top of book is unavailable', () => {
+    const instrument = createInstrument();
+
+    expect(() => instrument.buy(1, 50_000, { stopLimitPrice: 49_900 })).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- support BitMEX stop-market and stop-limit (flagged) order payloads and inference
- enforce stop trigger zone validation against best bid/ask during order prep
- cover stop workflows with new unit and integration tests, including REST/WS race handling

## Testing
- npm test -- --runTestsByPath tests/unit/infra/validation/place-input.spec.ts tests/unit/core/mappers/order-type.spec.ts tests/unit/core/mappers/order-payload.spec.ts tests/unit/domain/instrument-place.spec.ts tests/integration/trading/stop-market.lifecycle.spec.ts tests/integration/trading/stop-limit.flagged.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68ce85cb2d688320a60d4f5ce5e9268c