### PR TITLE
chore(bitmex): cleanup stop/stop-limit mapping; dedupe guards; unify error texts

### DIFF
--- a/src/core/bitmex/mappers/order.ts
+++ b/src/core/bitmex/mappers/order.ts
@@ -142,15 +142,6 @@ export function mapPreparedOrderToCreatePayload(input: PreparedPlaceInput): Crea
 
       payload.price = input.price;
       break;
-    case 'Stop':
-      if (input.stopPrice === null) {
-        throw new ValidationError('stop order requires stop price', {
-          details: { type: input.type },
-        });
-      }
-
-      payload.stopPx = input.stopPrice;
-      break;
     case 'StopLimit':
       if (input.price === null) {
         throw new ValidationError('stop-limit order requires limit price', {
@@ -158,14 +149,11 @@ export function mapPreparedOrderToCreatePayload(input: PreparedPlaceInput): Crea
         });
       }
 
-      if (input.stopPrice === null) {
-        throw new ValidationError('stop order requires stop price', {
-          details: { type: input.type },
-        });
-      }
-
       payload.price = input.price;
-      payload.stopPx = input.stopPrice;
+      applyStopPrice(payload, input);
+      break;
+    case 'Stop':
+      applyStopPrice(payload, input);
       break;
     default:
       break;
@@ -189,6 +177,16 @@ export function mapPreparedOrderToCreatePayload(input: PreparedPlaceInput): Crea
   }
 
   return payload;
+}
+
+function applyStopPrice(payload: CreateOrderPayload, input: PreparedPlaceInput): void {
+  if (input.stopPrice === null) {
+    throw new ValidationError('stop order requires stop price', {
+      details: { type: input.type },
+    });
+  }
+
+  payload.stopPx = input.stopPrice;
 }
 
 function normalizeTimeInForce(value: string | null | undefined): SupportedTimeInForce | null {

--- a/tests/unit/core/mappers/order-payload.spec.ts
+++ b/tests/unit/core/mappers/order-payload.spec.ts
@@ -103,4 +103,12 @@ describe('mapPreparedOrderToCreatePayload', () => {
       new ValidationError('stop-limit order requires limit price'),
     );
   });
+
+  test('throws when stop-limit payload misses stop price', () => {
+    const input = createPreparedInput({ type: 'StopLimit', price: 50_400, stopPrice: null });
+
+    expect(() => mapPreparedOrderToCreatePayload(input)).toThrowError(
+      new ValidationError('stop order requires stop price'),
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- deduplicated stop price guard between stop and stop-limit payloads while keeping existing order type logic
- ensured consistent error messages and removed redundant assignments in the BitMEX mapper
- expanded unit coverage for stop-limit orders missing stop prices

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cecbfc67c88320a55e29a99b4a18cc