### PR TITLE
test(integration): trading lifecycle coverage and examples

### DIFF
--- a/examples/place-order.ts
+++ b/examples/place-order.ts
@@ -1,0 +1,105 @@
+/* eslint-disable no-console */
+
+import { ExchangeHub } from '../src/ExchangeHub.js';
+import { genClOrdID } from '../src/infra/ids.js';
+import { validatePlaceInput, type PreparedPlaceInput } from '../src/infra/validation.js';
+
+function parsePositiveNumber(value: string | undefined, fallback: number, label: string): number {
+  if (value === undefined || value.trim() === '') {
+    return fallback;
+  }
+
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new Error(`${label} must be a positive number`);
+  }
+
+  return parsed;
+}
+
+async function main() {
+  const useTestnet = process.env.BITMEX_IS_TEST === 'true';
+  const hub = new ExchangeHub('BitMex', {
+    isTest: useTestnet,
+    apiKey: process.env.BITMEX_API_KEY,
+    apiSec: process.env.BITMEX_API_SECRET,
+  });
+
+  const symbol = (process.env.BITMEX_SYMBOL ?? 'XBTUSD').trim() || 'XBTUSD';
+  const size = parsePositiveNumber(process.env.BITMEX_ORDER_SIZE, 1, 'BITMEX_ORDER_SIZE');
+  const rawPrice = process.env.BITMEX_LIMIT_PRICE?.trim();
+  const priceValue = rawPrice && rawPrice.length > 0 ? Number(rawPrice) : undefined;
+
+  if (priceValue !== undefined && (!Number.isFinite(priceValue) || priceValue <= 0)) {
+    throw new Error('BITMEX_LIMIT_PRICE must be a positive number');
+  }
+
+  const sideEnv = (process.env.BITMEX_SIDE ?? 'buy').toLowerCase();
+  const side = sideEnv === 'sell' ? 'sell' : 'buy';
+  const type: PreparedPlaceInput['type'] = priceValue === undefined ? 'Market' : 'Limit';
+
+  const postOnly = type === 'Limit' && process.env.BITMEX_POST_ONLY === 'true';
+  const reduceOnly = process.env.BITMEX_REDUCE_ONLY === 'true';
+  const rawTif = process.env.BITMEX_TIME_IN_FORCE?.trim();
+  const timeInForce =
+    type === 'Limit' ? (rawTif && rawTif.length > 0 ? rawTif : 'GoodTillCancel') : undefined;
+
+  const clOrdId = process.env.BITMEX_CL_ORD_ID ?? genClOrdID(process.env.EH_PREFIX);
+
+  const normalized = validatePlaceInput({
+    symbol,
+    side,
+    size,
+    price: priceValue,
+    type,
+    opts: {
+      postOnly,
+      reduceOnly,
+      timeInForce,
+      clOrdID: clOrdId,
+    },
+  });
+
+  const prepared: PreparedPlaceInput = {
+    ...normalized,
+    options: { ...normalized.options, clOrdId },
+  };
+
+  try {
+    await hub.connect();
+
+    const place =
+      side === 'sell' ? hub.Core.sell.bind(hub.Core) : hub.Core.buy.bind(hub.Core);
+
+    console.log(
+      'Submitting %s %s order on %s (size=%d, price=%s, clOrdId=%s)',
+      type.toLowerCase(),
+      side.toUpperCase(),
+      symbol,
+      size,
+      type === 'Limit' ? normalized.price : 'MARKET',
+      clOrdId,
+    );
+
+    const order = await place(prepared);
+    const snapshot = order.getSnapshot();
+
+    console.log('Exchange accepted order %s with status %s', snapshot.orderId, snapshot.status);
+    console.log(
+      'execInst=%s leavesQty=%s avgFillPrice=%s',
+      snapshot.execInst,
+      snapshot.leavesQty,
+      snapshot.avgFillPrice,
+    );
+  } catch (error) {
+    console.error('Order placement failed', error);
+    process.exitCode = 1;
+  } finally {
+    await hub.disconnect().catch(() => undefined);
+  }
+}
+
+main().catch((error) => {
+  console.error('Unexpected error in place-order example', error);
+  process.exitCode = 1;
+});

--- a/tests/integration/trading/limit-postonly.lifecycle.spec.ts
+++ b/tests/integration/trading/limit-postonly.lifecycle.spec.ts
@@ -1,0 +1,176 @@
+import { jest } from '@jest/globals';
+
+import { OrderStatus } from '../../../src/domain/order.js';
+
+import type { PreparedPlaceInput } from '../../../src/infra/validation.js';
+
+import { createScenario } from '../../helpers/ws-mock/scenario.js';
+import { setupPrivateHarness } from '../../helpers/privateHarness.js';
+
+const ORIGINAL_FETCH = global.fetch;
+
+function createPreparedLimit(overrides: Partial<PreparedPlaceInput> = {}): PreparedPlaceInput {
+  const base: PreparedPlaceInput = {
+    symbol: 'XBTUSD',
+    side: 'buy',
+    size: 30,
+    type: 'Limit',
+    price: 50_050,
+    stopPrice: null,
+    options: {
+      postOnly: true,
+      reduceOnly: false,
+      timeInForce: 'GoodTillCancel',
+      clOrdId: 'limit-cli-1',
+    },
+  };
+
+  return {
+    ...base,
+    ...overrides,
+    options: { ...base.options, ...overrides.options },
+  };
+}
+
+describe('BitMEX trading – limit post-only lifecycle', () => {
+  afterEach(() => {
+    global.fetch = ORIGINAL_FETCH;
+    jest.restoreAllMocks();
+  });
+
+  test('places a passive limit order and observes cancellation via WS updates', async () => {
+    const scenario = createScenario()
+      .open()
+      .requireAuth()
+      .expectAuth()
+      .expectSubscribe(['wallet', 'position', 'order'])
+      .sendSubscribeAck(['wallet', 'position', 'order'])
+      .sendPartial('order', [])
+      .delay(25)
+      .sendInsert('order', [
+        {
+          orderID: 'limit-ord-1',
+          clOrdID: 'limit-cli-1',
+          symbol: 'XBTUSD',
+          side: 'Buy',
+          orderQty: 30,
+          ordType: 'Limit',
+          ordStatus: 'New',
+          execType: 'New',
+          price: 50_050,
+          leavesQty: 30,
+          cumQty: 0,
+          avgPx: 0,
+          timestamp: '2024-01-01T00:00:01.000Z',
+        },
+      ])
+      .delay(100)
+      .sendUpdate('order', [
+        {
+          orderID: 'limit-ord-1',
+          clOrdID: 'limit-cli-1',
+          symbol: 'XBTUSD',
+          side: 'Buy',
+          orderQty: 30,
+          ordStatus: 'Canceled',
+          execType: 'Canceled',
+          leavesQty: 0,
+          cumQty: 0,
+          avgPx: 0,
+          text: 'Canceled: Post-only would cross the book',
+          timestamp: '2024-01-01T00:00:03.000Z',
+        },
+      ])
+      .build();
+
+    const harness = await setupPrivateHarness(scenario, {
+      startTime: '2024-01-01T00:00:00.000Z',
+    });
+    const { clock, hub, core, server } = harness;
+
+    const mockFetch = jest.fn(
+      () =>
+        new Promise<Response>((resolve) => {
+          setTimeout(() => {
+            resolve(
+              new Response(
+                JSON.stringify({
+                  orderID: 'limit-ord-1',
+                  clOrdID: 'limit-cli-1',
+                  symbol: 'XBTUSD',
+                  side: 'Buy',
+                  orderQty: 30,
+                  ordType: 'Limit',
+                  ordStatus: 'New',
+                  execType: 'New',
+                  price: 50_050,
+                  leavesQty: 30,
+                  cumQty: 0,
+                  avgPx: 0,
+                  execInst: 'ParticipateDoNotInitiate',
+                  timestamp: '2024-01-01T00:00:01.500Z',
+                }),
+                { status: 200 },
+              ),
+            );
+          }, 120);
+        }),
+    );
+
+    global.fetch = mockFetch as unknown as typeof fetch;
+
+    const prepared = createPreparedLimit();
+    const orderPromise = core.buy(prepared);
+
+    expect(hub.orders.getInflightByClOrdId('limit-cli-1')).toBeDefined();
+
+    await clock.waitFor(() => hub.orders.getByClOrdId('limit-cli-1') !== undefined);
+    await clock.waitFor(
+      () =>
+        hub.orders.getByClOrdId('limit-cli-1')?.getSnapshot().execInst ===
+        'ParticipateDoNotInitiate',
+    );
+
+    const resting = hub.orders.getByClOrdId('limit-cli-1');
+    expect(resting).toBeDefined();
+    expect(resting!.getSnapshot()).toMatchObject({
+      status: OrderStatus.Placed,
+      type: 'Limit',
+      price: 50_050,
+      execInst: 'ParticipateDoNotInitiate',
+    });
+
+    await clock.waitFor(
+      () => hub.orders.getByClOrdId('limit-cli-1')?.getSnapshot().status === OrderStatus.Canceled,
+    );
+
+    await clock.wait(200);
+    const order = await orderPromise;
+    expect(order).toBe(resting);
+
+    const snapshot = order.getSnapshot();
+    expect(snapshot.status).toBe(OrderStatus.Canceled);
+    expect(snapshot.execInst).toBe('ParticipateDoNotInitiate');
+    expect(snapshot.text).toContain('Post-only');
+
+    expect(hub.orders.getInflightByClOrdId('limit-cli-1')).toBeUndefined();
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [, init] = mockFetch.mock.calls[0] as [RequestInfo | URL, RequestInit];
+    const body = JSON.parse(String(init.body));
+    expect(body).toMatchObject({
+      symbol: 'XBTUSD',
+      side: 'Buy',
+      orderQty: 30,
+      ordType: 'Limit',
+      price: 50_050,
+      clOrdID: 'limit-cli-1',
+      execInst: 'ParticipateDoNotInitiate',
+      timeInForce: 'GoodTillCancel',
+    });
+
+    await server.waitForCompletion();
+    await clock.wait(10);
+    await harness.cleanup();
+  });
+});

--- a/tests/integration/trading/market.lifecycle.spec.ts
+++ b/tests/integration/trading/market.lifecycle.spec.ts
@@ -1,0 +1,162 @@
+import { jest } from '@jest/globals';
+
+import { OrderStatus } from '../../../src/domain/order.js';
+
+import type { PreparedPlaceInput } from '../../../src/infra/validation.js';
+
+import { createScenario } from '../../helpers/ws-mock/scenario.js';
+import { setupPrivateHarness } from '../../helpers/privateHarness.js';
+
+const ORIGINAL_FETCH = global.fetch;
+
+function createPreparedMarket(overrides: Partial<PreparedPlaceInput> = {}): PreparedPlaceInput {
+  const base: PreparedPlaceInput = {
+    symbol: 'XBTUSD',
+    side: 'buy',
+    size: 10,
+    type: 'Market',
+    price: null,
+    stopPrice: null,
+    options: {
+      postOnly: false,
+      reduceOnly: false,
+      timeInForce: null,
+      clOrdId: 'market-cli-1',
+    },
+  };
+
+  return {
+    ...base,
+    ...overrides,
+    options: { ...base.options, ...overrides.options },
+  };
+}
+
+describe('BitMEX trading – market lifecycle', () => {
+  afterEach(() => {
+    global.fetch = ORIGINAL_FETCH;
+    jest.restoreAllMocks();
+  });
+
+  test('tracks market order fills emitted by the private stream', async () => {
+    const scenario = createScenario()
+      .open()
+      .requireAuth()
+      .expectAuth()
+      .expectSubscribe(['wallet', 'position', 'order'])
+      .sendSubscribeAck(['wallet', 'position', 'order'])
+      .sendPartial('order', [])
+      .delay(20)
+      .sendInsert('order', [
+        {
+          orderID: 'market-ord-1',
+          clOrdID: 'market-cli-1',
+          symbol: 'XBTUSD',
+          side: 'Buy',
+          orderQty: 10,
+          ordType: 'Market',
+          ordStatus: 'New',
+          execType: 'New',
+          leavesQty: 10,
+          cumQty: 0,
+          avgPx: 0,
+          timestamp: '2024-01-01T00:00:01.000Z',
+        },
+      ])
+      .delay(50)
+      .sendUpdate('order', [
+        {
+          orderID: 'market-ord-1',
+          clOrdID: 'market-cli-1',
+          symbol: 'XBTUSD',
+          side: 'Buy',
+          orderQty: 10,
+          ordStatus: 'Filled',
+          execType: 'Trade',
+          leavesQty: 0,
+          cumQty: 10,
+          avgPx: 50_100,
+          lastQty: 10,
+          lastPx: 50_100,
+          transactTime: '2024-01-01T00:00:02.000Z',
+        },
+      ])
+      .build();
+
+    const harness = await setupPrivateHarness(scenario, {
+      startTime: '2024-01-01T00:00:00.000Z',
+    });
+    const { clock, hub, core, server } = harness;
+
+    const mockFetch = jest.fn(
+      () =>
+        new Promise<Response>((resolve) => {
+          setTimeout(() => {
+            resolve(
+              new Response(
+                JSON.stringify({
+                  orderID: 'market-ord-1',
+                  clOrdID: 'market-cli-1',
+                  symbol: 'XBTUSD',
+                  side: 'Buy',
+                  orderQty: 10,
+                  ordType: 'Market',
+                  ordStatus: 'Filled',
+                  execType: 'Trade',
+                  leavesQty: 0,
+                  cumQty: 10,
+                  avgPx: 50_100,
+                  timestamp: '2024-01-01T00:00:02.500Z',
+                }),
+                { status: 200 },
+              ),
+            );
+          }, 150);
+        }),
+    );
+
+    global.fetch = mockFetch as unknown as typeof fetch;
+
+    const prepared = createPreparedMarket();
+    const orderPromise = core.buy(prepared);
+
+    expect(hub.orders.getInflightByClOrdId('market-cli-1')).toBeDefined();
+
+    await clock.waitFor(() => hub.orders.getByClOrdId('market-cli-1') !== undefined);
+
+    const interim = hub.orders.getByClOrdId('market-cli-1');
+    expect(interim).toBeDefined();
+    expect(interim!.getSnapshot().status).toBe(OrderStatus.Placed);
+
+    await clock.waitFor(
+      () => hub.orders.getByClOrdId('market-cli-1')?.getSnapshot().status === OrderStatus.Filled,
+    );
+
+    await clock.wait(200);
+    const order = await orderPromise;
+    expect(order).toBe(interim);
+
+    const snapshot = order.getSnapshot();
+    expect(snapshot.status).toBe(OrderStatus.Filled);
+    expect(snapshot.filledQty).toBe(10);
+    expect(snapshot.avgFillPrice).toBeCloseTo(50_100, 6);
+    expect(snapshot.type).toBe('Market');
+
+    expect(hub.orders.getInflightByClOrdId('market-cli-1')).toBeUndefined();
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [, init] = mockFetch.mock.calls[0] as [RequestInfo | URL, RequestInit];
+    const body = JSON.parse(String(init.body));
+    expect(body).toMatchObject({
+      symbol: 'XBTUSD',
+      side: 'Buy',
+      orderQty: 10,
+      ordType: 'Market',
+      clOrdID: 'market-cli-1',
+    });
+
+    await server.waitForCompletion();
+    await clock.wait(10);
+    await harness.cleanup();
+  });
+});


### PR DESCRIPTION
## Summary
- add market and post-only lifecycle scenarios that exercise WS/REST coordination
- assert create-order metrics in the existing idempotency, retry and timeout integration specs
- provide a place-order quick start example and extend the README trading section

## Testing
- npx jest tests/integration/trading --runInBand (x3)


------
https://chatgpt.com/codex/tasks/task_e_68cee2b18414832092d31efcd7654330