### PR TITLE
docs(examples): clarify clOrdID vs clOrdId; add package-import and .env tip

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,11 @@ BitMEX и большинство бирж требуют, чтобы `clOrdID` �
 важно придерживаться договорённостей по префиксам, чтобы избежать конфликтов в
 кластерной среде.
 
+> BitMEX ожидает поле `clOrdID` (с заглавной `ID`) в исходном payload, а
+> ExchangeHub нормализует его до `clOrdId` внутри подготовленной структуры.
+> Повторное использование одного и того же значения гарантирует идемпотентность
+> постановки ордеров, вне зависимости от регистра последней буквы.
+
 ```ts
 import { ExchangeHub, genClOrdID } from 'exchange-hub';
 
@@ -146,18 +151,20 @@ import { validatePlaceInput } from 'exchange-hub/validation';
 
 const hub = new ExchangeHub('BitMex', { apiKey: '...', apiSec: '...' });
 
+const clOrdId = genClOrdID('desk-a');
+
 const normalized = validatePlaceInput({
   symbol: 'XBTUSD',
   side: 'buy',
   size: 10,
   type: 'Limit',
   price: 50_000,
-  opts: { postOnly: true, timeInForce: 'GoodTillCancel', clOrdID: genClOrdID('desk-a') },
+  opts: { postOnly: true, timeInForce: 'GoodTillCancel', clOrdID: clOrdId },
 });
 
 const order = await hub.Core.buy({
   ...normalized,
-  options: { ...normalized.options, clOrdId: normalized.options.clOrdId ?? genClOrdID('desk-a') },
+  options: { ...normalized.options, clOrdId },
 });
 
 order.on('update', (snapshot) => {
@@ -168,6 +175,15 @@ order.on('update', (snapshot) => {
 Готовый пример «быстрого старта» расположен в `examples/place-order.ts`. Он
 показывает, как собрать payload из переменных окружения и отправить лимитный или
 рыночный ордер на Node.js 22.
+
+### Quick start with env
+
+Подготовьте `.env` с ключами BitMEX и запустите пример:
+
+```bash
+cp .env.example .env # заполните значения
+node --env-file=.env examples/place-order.ts
+```
 
 ## Domain events & types
 

--- a/examples/place-order.ts
+++ b/examples/place-order.ts
@@ -1,4 +1,7 @@
 /* eslint-disable no-console */
+// Для использования вне репозитория:
+// import { ExchangeHub, genClOrdID } from 'exchange-hub';
+// import { validatePlaceInput, type PreparedPlaceInput } from 'exchange-hub/validation';
 
 import { ExchangeHub } from '../src/ExchangeHub.js';
 import { genClOrdID } from '../src/infra/ids.js';
@@ -68,8 +71,7 @@ async function main() {
   try {
     await hub.connect();
 
-    const place =
-      side === 'sell' ? hub.Core.sell.bind(hub.Core) : hub.Core.buy.bind(hub.Core);
+    const place = side === 'sell' ? hub.Core.sell.bind(hub.Core) : hub.Core.buy.bind(hub.Core);
 
     console.log(
       'Submitting %s %s order on %s (size=%d, price=%s, clOrdId=%s)',


### PR DESCRIPTION
## Summary
- clarify how `clOrdID` inputs map to normalized `clOrdId` options and keep the trading snippet consistent
- add a quick-start snippet that highlights running the example with a `.env`
- document the package import paths directly in the example file

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cef410f7108320bb40fa32d8ff6268