### PR TITLE
refactor: switch private fields to native syntax

### DIFF
--- a/src/core/private/resubscribe-flow.ts
+++ b/src/core/private/resubscribe-flow.ts
@@ -4,9 +4,13 @@ export interface PrivateResubscribeFlow {
 }
 
 export class DefaultPrivateResubscribeFlow implements PrivateResubscribeFlow {
-    constructor(private readonly doResubscribe: () => Promise<void>) {}
+    readonly #doResubscribe: () => Promise<void>;
+
+    constructor(doResubscribe: () => Promise<void>) {
+        this.#doResubscribe = doResubscribe;
+    }
 
     async onAuthedResubscribe(): Promise<void> {
-        await this.doResubscribe();
+        await this.#doResubscribe();
     }
 }


### PR DESCRIPTION
## Summary
- replace BitmexWsClient class fields declared with the private modifier by native ECMAScript private identifiers and adjust all references
- store the resubscribe callback in DefaultPrivateResubscribeFlow on an ECMAScript private field instead of a constructor property modifier

## Testing
- npm run type-check *(fails due to pre-existing TypeScript errors unrelated to these changes)*

------
https://chatgpt.com/codex/tasks/task_e_68d0f56ad35c8320ae6050d2a7155cfd