### PR TITLE
Replace empty handlers with noop utilities

### DIFF
--- a/src/core/bitmex/index.ts
+++ b/src/core/bitmex/index.ts
@@ -10,7 +10,6 @@ import { mapBitmexOrderStatus, mapPreparedOrderToCreatePayload } from './mappers
 import type { CreateOrderPayload } from './rest/orders';
 import { BaseCore } from '../BaseCore';
 import { getUnifiedSymbolAliases, mapSymbolNativeToUni } from '../../utils/symbolMapping';
-import { noop } from '../../utils/noop';
 import { Instrument } from '../../domain/instrument';
 import type { Order, OrderStatus, type OrderInit, type OrderUpdate } from '../../domain/order';
 import { createLogger } from '../../infra/logger';
@@ -518,8 +517,8 @@ export class BitMex extends BaseCore<'BitMex'> {
         throw new Error('Unknown message');
     }
 
-    #handleWelcomeMessage(message: BitMexWelcomeMessage) {
-        noop(message);
+    #handleWelcomeMessage(_message: BitMexWelcomeMessage) {
+        throw new Error('not implemented');
     }
 
     #handleSubscribeMessage(message: BitMexSubscribeMessage) {

--- a/src/core/bitmex/index.ts
+++ b/src/core/bitmex/index.ts
@@ -10,6 +10,7 @@ import { mapBitmexOrderStatus, mapPreparedOrderToCreatePayload } from './mappers
 import type { CreateOrderPayload } from './rest/orders';
 import { BaseCore } from '../BaseCore';
 import { getUnifiedSymbolAliases, mapSymbolNativeToUni } from '../../utils/symbolMapping';
+import { noop } from '../../utils/noop';
 import { Instrument } from '../../domain/instrument';
 import type { Order, OrderStatus, type OrderInit, type OrderUpdate } from '../../domain/order';
 import { createLogger } from '../../infra/logger';
@@ -517,7 +518,9 @@ export class BitMex extends BaseCore<'BitMex'> {
         throw new Error('Unknown message');
     }
 
-    #handleWelcomeMessage(_message: BitMexWelcomeMessage) {}
+    #handleWelcomeMessage(message: BitMexWelcomeMessage) {
+        noop(message);
+    }
 
     #handleSubscribeMessage(message: BitMexSubscribeMessage) {
         if (!message.success) {

--- a/tests/bitmex/instrument.test.ts
+++ b/tests/bitmex/instrument.test.ts
@@ -7,6 +7,7 @@ import {
 } from '../../src/core/bitmex/channels/instrument';
 import { Instrument } from '../../src/domain/instrument';
 import { mapSymbolNativeToUni, mapSymbolUniToNative } from '../../src/utils/symbolMapping';
+import { noop } from '../../src/utils/noop';
 import type { BitMex } from '../../src/core/bitmex/index';
 import type { BitMexInstrument } from '../../src/core/bitmex/types';
 import type { Settings } from '../../src/types';
@@ -32,7 +33,9 @@ class FakeWebSocket {
         this.#listeners.get(event)?.delete(listener);
     }
 
-    send(_data: string): void {}
+    send(data: string): void {
+        noop(data);
+    }
 
     close(): void {
         this.#emit('close');

--- a/tests/bitmex/orderbook.unit.test.ts
+++ b/tests/bitmex/orderbook.unit.test.ts
@@ -1,6 +1,7 @@
 import { ExchangeHub } from '../../src/ExchangeHub';
 import { handleInstrumentPartial } from '../../src/core/bitmex/channels/instrument';
 import { OrderBookL2 } from '../../src/domain/orderBookL2';
+import { noop } from '../../src/utils/noop';
 import type { BitMex } from '../../src/core/bitmex/index';
 import type { BitMexInstrument } from '../../src/core/bitmex/types';
 import type { L2Row } from '../../src/types/orderbook';
@@ -30,7 +31,9 @@ class NoopWebSocket {
         this.#listeners.get(event)?.delete(listener);
     }
 
-    send(_data: string): void {}
+    send(data: string): void {
+        noop(data);
+    }
 
     close(): void {
         this.#emit('close');

--- a/tests/bitmex/trade.test.ts
+++ b/tests/bitmex/trade.test.ts
@@ -2,6 +2,7 @@ import { ExchangeHub } from '../../src/ExchangeHub';
 import { handleInstrumentPartial } from '../../src/core/bitmex/channels/instrument';
 import { handleTradeInsert, handleTradePartial } from '../../src/core/bitmex/channels/trade';
 import { TRADE_BUFFER_DEFAULT } from '../../src/core/bitmex/constants';
+import { noop } from '../../src/utils/noop';
 import type { BitMex } from '../../src/core/bitmex/index';
 import type { BitMexInstrument } from '../../src/core/bitmex/types';
 import type { BitmexTradeRaw } from '../../src/types/bitmex';
@@ -28,7 +29,9 @@ class FakeWebSocket {
         this.#listeners.get(event)?.delete(listener);
     }
 
-    send(_data: string): void {}
+    send(data: string): void {
+        noop(data);
+    }
 
     close(): void {
         this.#emit('close');

--- a/tests/helpers/privateHarness.ts
+++ b/tests/helpers/privateHarness.ts
@@ -11,6 +11,7 @@ import { isChannelMessage, isSubscribeMessage } from '../../src/core/bitmex/util
 import { resetMetrics } from '../../src/infra/metrics';
 import type { BitMexChannel, BitMexChannelMessage } from '../../src/core/bitmex/types';
 import type { ScenarioScript } from './ws-mock/scenario';
+import { noop as noopFn } from '../../src/utils/noop';
 
 export type PrivateHarnessOptions = TestClockOptions;
 
@@ -144,7 +145,9 @@ function createNoopWebSocket(): {
             this.#listeners.get(event)?.delete(listener);
         }
 
-        send(_data: string): void {}
+        send(data: string): void {
+            noopFn(data);
+        }
 
         close(): void {
             this.#emit('close', { code: 1000, reason: 'noop' });

--- a/tests/integration/private/order-stream.test.ts
+++ b/tests/integration/private/order-stream.test.ts
@@ -1,6 +1,7 @@
 import { ExchangeHub } from '../../../src/ExchangeHub';
 import { handleOrderMessage, markOrderChannelAwaitingSnapshot } from '../../../src/core/bitmex/channels/order';
 import { OrderStatus } from '../../../src/domain/order';
+import { noop } from '../../../src/utils/noop';
 import type { BitMex } from '../../../src/core/bitmex/index';
 import type { BitMexOrder } from '../../../src/core/bitmex/types';
 import type { Settings } from '../../../src/types';
@@ -26,7 +27,9 @@ class FakeWebSocket {
         this.#listeners.get(event)?.delete(listener);
     }
 
-    send(_data: string): void {}
+    send(data: string): void {
+        noop(data);
+    }
 
     close(): void {
         this.#emit('close');

--- a/tests/integration/private/position-stream.test.ts
+++ b/tests/integration/private/position-stream.test.ts
@@ -10,6 +10,7 @@ import {
     handlePositionUpdate,
     markPositionsAwaitingResync,
 } from '../../../src/core/bitmex/channels/position';
+import { noop } from '../../../src/utils/noop';
 
 let metrics!: MetricsModule;
 
@@ -41,7 +42,9 @@ class ControlledWebSocket {
         this.#listeners.get(event)?.delete(listener);
     }
 
-    send(_data: string): void {}
+    send(data: string): void {
+        noop(data);
+    }
 
     close(): void {
         this.#emit('close', { code: 1000, reason: 'client-request' });

--- a/tests/integration/private/wallet-stream.test.ts
+++ b/tests/integration/private/wallet-stream.test.ts
@@ -4,6 +4,7 @@ import type { WalletSnapshot } from '../../../src/domain/wallet';
 import { ExchangeHub } from '../../../src/ExchangeHub';
 import { METRICS } from '../../../src/infra/metrics-private';
 import { getCounterValue, getHistogramValues, resetMetrics } from '../../../src/infra/metrics';
+import { noop } from '../../../src/utils/noop';
 
 const ORIGINAL_WEBSOCKET = (globalThis as any).WebSocket;
 
@@ -373,7 +374,9 @@ class ControlledWebSocket {
         this.#listeners.get(event)?.delete(listener);
     }
 
-    send(_data: string): void {}
+    send(data: string): void {
+        noop(data);
+    }
 
     close(): void {
         this.#emit('close', { code: 1000, reason: 'client-request' });

--- a/tests/unit/core/private/resubscribe-flow.test.ts
+++ b/tests/unit/core/private/resubscribe-flow.test.ts
@@ -1,8 +1,9 @@
 import { DefaultPrivateResubscribeFlow } from '../../../../src/core/private/resubscribe-flow';
+import { asyncNoop } from '../../../../src/utils/noop';
 
 describe('DefaultPrivateResubscribeFlow', () => {
     test('DefaultPrivateResubscribeFlow вызывает doResubscribe() ровно один раз на вызов onAuthedResubscribe()', async () => {
-        const doResubscribe = jest.fn(async () => {});
+        const doResubscribe = jest.fn(asyncNoop);
         const flow = new DefaultPrivateResubscribeFlow(doResubscribe);
 
         await flow.onAuthedResubscribe();

--- a/tests/ws/orderbook.smoke.test.ts
+++ b/tests/ws/orderbook.smoke.test.ts
@@ -5,6 +5,7 @@ import type { BitMexChannelMessage, BitMexInstrument } from '../../src/core/bitm
 import type { Logger } from '../../src/infra/logger';
 import type { BitmexOrderBookL2Raw } from '../../src/types/bitmex';
 import type { L2BatchDelta } from '../../src/types/orderbook';
+import { noop } from '../../src/utils/noop';
 
 const orderBookLogger: Logger = {
     level: jest.fn(() => 'debug'),
@@ -67,7 +68,9 @@ class ControlledWebSocket {
         this.#listeners.get(event)?.delete(listener);
     }
 
-    send(_data: string): void {}
+    send(data: string): void {
+        noop(data);
+    }
 
     close(): void {
         this.#emit('close', { code: 1000, reason: 'client-request' });

--- a/tests/ws/trade.smoke.test.ts
+++ b/tests/ws/trade.smoke.test.ts
@@ -2,6 +2,7 @@ import type { BitMexChannelMessage, BitMexInstrument } from '../../src/core/bitm
 import { ExchangeHub } from '../../src/ExchangeHub';
 import { handleInstrumentPartial } from '../../src/core/bitmex/channels/instrument';
 import { TRADE_BUFFER_DEFAULT } from '../../src/core/bitmex/constants';
+import { noop } from '../../src/utils/noop';
 import type { BitMex } from '../../src/core/bitmex/index';
 import type { BitmexTradeRaw } from '../../src/types/bitmex';
 
@@ -33,7 +34,9 @@ class ControlledWebSocket {
         this.#listeners.get(event)?.delete(listener);
     }
 
-    send(_data: string): void {}
+    send(data: string): void {
+        noop(data);
+    }
 
     close(): void {
         this.#emit('close', { code: 1000, reason: 'client-request' });


### PR DESCRIPTION
## Summary
- invoke the noop utility in the BitMEX welcome handler to satisfy the no-empty-function rule
- route WebSocket send stubs and the resubscribe flow mock through noop/asyncNoop so tests comply with the lint change

## Testing
- npm run lint *(fails on unrelated pre-existing lint violations)*
- npx eslint src/core/bitmex/index.ts tests/bitmex/instrument.test.ts tests/bitmex/orderbook.unit.test.ts tests/bitmex/trade.test.ts tests/helpers/privateHarness.ts tests/integration/private/order-stream.test.ts tests/integration/private/position-stream.test.ts tests/integration/private/wallet-stream.test.ts tests/unit/core/private/resubscribe-flow.test.ts tests/ws/orderbook.smoke.test.ts tests/ws/trade.smoke.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d0fbc2ec2c83208a071cc4d8cd3d3d