### PR TITLE
Add lint rule forbidding readonly modifier

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -189,6 +189,10 @@ module.exports = [
                     selector: 'TSParameterProperty[accessibility]',
                     message: 'Accessibility modifiers are not allowed. Use # for private fields.',
                 },
+                {
+                    selector: ':matches(PropertyDefinition, TSParameterProperty)[readonly=true]',
+                    message: 'Readonly modifier is not allowed. Use a # prefixed field with a getter instead.',
+                },
             ],
         },
         linterOptions: {


### PR DESCRIPTION
## Summary
- add an ESLint `no-restricted-syntax` selector that disallows the TypeScript `readonly` modifier on class properties and parameter properties

## Testing
- npm run lint *(fails: existing files violate the new readonly restriction and other pre-existing lint issues)*

------
https://chatgpt.com/codex/tasks/task_e_68d102477e6c8320bd4ec74b798262a0