### PR TITLE
Fix RequestInit lint errors

### DIFF
--- a/tests/fetch-types.ts
+++ b/tests/fetch-types.ts
@@ -1,0 +1,2 @@
+export type FetchRequestInfo = Parameters<typeof fetch>[0];
+export type FetchRequestInit = NonNullable<Parameters<typeof fetch>[1]>;

--- a/tests/integration/rest/create-order.limit-postonly.spec.ts
+++ b/tests/integration/rest/create-order.limit-postonly.spec.ts
@@ -4,6 +4,7 @@ import { ExchangeHub } from '../../../src/ExchangeHub';
 import { OrderStatus } from '../../../src/domain/order';
 import type { BitMex } from '../../../src/core/bitmex/index';
 import type { PreparedPlaceInput } from '../../../src/infra/validation';
+import type { FetchRequestInit, FetchRequestInfo } from '../../fetch-types';
 
 const ORIGINAL_FETCH = global.fetch;
 
@@ -65,7 +66,7 @@ describe('BitMEX REST createOrder – limit/postOnly', () => {
 
         expect(mockFetch).toHaveBeenCalledTimes(1);
 
-        const [, init] = mockFetch.mock.calls[0] as [RequestInfo | URL, RequestInit];
+        const [, init] = mockFetch.mock.calls[0] as [FetchRequestInfo | URL, FetchRequestInit];
         const body = JSON.parse(String(init.body));
 
         expect(body).toMatchObject({
@@ -128,7 +129,7 @@ describe('BitMEX REST createOrder – limit/postOnly', () => {
 
         await core.buy(prepared);
 
-        const [, init] = mockFetch.mock.calls[0] as [RequestInfo | URL, RequestInit];
+        const [, init] = mockFetch.mock.calls[0] as [FetchRequestInfo | URL, FetchRequestInit];
         const body = JSON.parse(String(init.body));
 
         expect(body.execInst).toBe('ParticipateDoNotInitiate,ReduceOnly');

--- a/tests/integration/rest/create-order.market.spec.ts
+++ b/tests/integration/rest/create-order.market.spec.ts
@@ -5,6 +5,7 @@ import { OrderStatus } from '../../../src/domain/order';
 import { RateLimitError } from '../../../src/infra/errors';
 import type { BitMex } from '../../../src/core/bitmex/index';
 import type { PreparedPlaceInput } from '../../../src/infra/validation';
+import type { FetchRequestInit, FetchRequestInfo } from '../../fetch-types';
 
 const ORIGINAL_FETCH = global.fetch;
 
@@ -70,7 +71,7 @@ describe('BitMEX REST createOrder – market', () => {
 
         expect(mockFetch).toHaveBeenCalledTimes(1);
 
-        const [url, init] = mockFetch.mock.calls[0] as [RequestInfo | URL, RequestInit];
+        const [url, init] = mockFetch.mock.calls[0] as [FetchRequestInfo | URL, FetchRequestInit];
 
         expect(String(url)).toBe('https://testnet.bitmex.com/api/v1/order');
         expect(init.method).toBe('POST');
@@ -290,7 +291,7 @@ describe('BitMEX REST createOrder – market', () => {
 
         expect(mockFetch).toHaveBeenCalledTimes(1);
 
-        const [url, init] = mockFetch.mock.calls[0] as [RequestInfo | URL, RequestInit];
+        const [url, init] = mockFetch.mock.calls[0] as [FetchRequestInfo | URL, FetchRequestInit];
 
         expect(String(url)).toBe('https://testnet.bitmex.com/api/v1/order');
         expect(init.method).toBe('POST');

--- a/tests/integration/rest/create-order.postonly-guard.spec.ts
+++ b/tests/integration/rest/create-order.postonly-guard.spec.ts
@@ -4,6 +4,7 @@ import { ExchangeHub } from '../../../src/ExchangeHub';
 import { ValidationError } from '../../../src/infra/errors';
 import type { BitMex } from '../../../src/core/bitmex/index';
 import type { PreparedPlaceInput } from '../../../src/infra/validation';
+import type { FetchRequestInit, FetchRequestInfo } from '../../fetch-types';
 
 const ORIGINAL_FETCH = global.fetch;
 
@@ -98,7 +99,7 @@ describe('BitMEX REST createOrder – postOnly guard', () => {
 
         expect(mockFetch).toHaveBeenCalledTimes(1);
 
-        const [, init] = mockFetch.mock.calls[0] as [RequestInfo | URL, RequestInit];
+        const [, init] = mockFetch.mock.calls[0] as [FetchRequestInfo | URL, FetchRequestInit];
         const body = JSON.parse(String(init.body));
 
         expect(body.execInst).toBe('ParticipateDoNotInitiate');

--- a/tests/integration/trading/limit-postonly.lifecycle.spec.ts
+++ b/tests/integration/trading/limit-postonly.lifecycle.spec.ts
@@ -4,6 +4,7 @@ import { OrderStatus } from '../../../src/domain/order';
 import type { PreparedPlaceInput } from '../../../src/infra/validation';
 import { createScenario } from '../../helpers/ws-mock/scenario';
 import { setupPrivateHarness } from '../../helpers/privateHarness';
+import type { FetchRequestInit, FetchRequestInfo } from '../../fetch-types';
 
 const ORIGINAL_FETCH = global.fetch;
 
@@ -157,7 +158,7 @@ describe('BitMEX trading – limit post-only lifecycle', () => {
 
         expect(mockFetch).toHaveBeenCalledTimes(1);
 
-        const [, init] = mockFetch.mock.calls[0] as [RequestInfo | URL, RequestInit];
+        const [, init] = mockFetch.mock.calls[0] as [FetchRequestInfo | URL, FetchRequestInit];
         const body = JSON.parse(String(init.body));
 
         expect(body).toMatchObject({

--- a/tests/integration/trading/market.lifecycle.spec.ts
+++ b/tests/integration/trading/market.lifecycle.spec.ts
@@ -4,6 +4,7 @@ import { OrderStatus } from '../../../src/domain/order';
 import type { PreparedPlaceInput } from '../../../src/infra/validation';
 import { createScenario } from '../../helpers/ws-mock/scenario';
 import { setupPrivateHarness } from '../../helpers/privateHarness';
+import type { FetchRequestInit, FetchRequestInfo } from '../../fetch-types';
 
 const ORIGINAL_FETCH = global.fetch;
 
@@ -146,7 +147,7 @@ describe('BitMEX trading – market lifecycle', () => {
 
         expect(mockFetch).toHaveBeenCalledTimes(1);
 
-        const [, init] = mockFetch.mock.calls[0] as [RequestInfo | URL, RequestInit];
+        const [, init] = mockFetch.mock.calls[0] as [FetchRequestInfo | URL, FetchRequestInit];
         const body = JSON.parse(String(init.body));
 
         expect(body).toMatchObject({

--- a/tests/integration/trading/network-retry.spec.ts
+++ b/tests/integration/trading/network-retry.spec.ts
@@ -6,6 +6,7 @@ import { getHistogramValues, resetMetrics } from '../../../src/infra/metrics';
 import { RateLimitError } from '../../../src/infra/errors';
 import type { BitMex } from '../../../src/core/bitmex/index';
 import type { PreparedPlaceInput } from '../../../src/infra/validation';
+import type { FetchRequestInit } from '../../fetch-types';
 
 const ORIGINAL_FETCH = global.fetch;
 
@@ -85,8 +86,12 @@ describe('BitMEX trading – network retry', () => {
         });
 
         expect(mockFetch).toHaveBeenCalledTimes(2);
-        expect((mockFetch.mock.calls[0]?.[1] as RequestInit | undefined)?.method ?? 'GET').toBe('POST');
-        expect((mockFetch.mock.calls[1]?.[1] as RequestInit | undefined)?.method ?? 'GET').toBe('POST');
+
+        const firstRequest = mockFetch.mock.calls[0]?.[1] as FetchRequestInit | undefined;
+        const secondRequest = mockFetch.mock.calls[1]?.[1] as FetchRequestInit | undefined;
+
+        expect(firstRequest?.method ?? 'GET').toBe('POST');
+        expect(secondRequest?.method ?? 'GET').toBe('POST');
 
         expect(hub.orders.getByClOrdId('retry-cli-1')).toBe(order);
         expect(hub.orders.getInflightByClOrdId('retry-cli-1')).toBeUndefined();
@@ -119,7 +124,10 @@ describe('BitMEX trading – network retry', () => {
         await expect(core.buy(prepared)).rejects.toBeInstanceOf(RateLimitError);
 
         expect(mockFetch).toHaveBeenCalledTimes(1);
-        expect((mockFetch.mock.calls[0]?.[1] as RequestInit | undefined)?.method ?? 'GET').toBe('POST');
+
+        const firstRequest = mockFetch.mock.calls[0]?.[1] as FetchRequestInit | undefined;
+
+        expect(firstRequest?.method ?? 'GET').toBe('POST');
 
         expect(hub.orders.getByClOrdId('retry-cli-429')).toBeUndefined();
         expect(hub.orders.getInflightByClOrdId('retry-cli-429')).toBeUndefined();

--- a/tests/integration/trading/race-ws-vs-rest.spec.ts
+++ b/tests/integration/trading/race-ws-vs-rest.spec.ts
@@ -4,6 +4,7 @@ import { ExchangeHub } from '../../../src/ExchangeHub';
 import { OrderStatus } from '../../../src/domain/order';
 import type { BitMex } from '../../../src/core/bitmex/index';
 import type { PreparedPlaceInput } from '../../../src/infra/validation';
+import type { FetchRequestInit, FetchRequestInfo } from '../../fetch-types';
 
 const ORIGINAL_FETCH = global.fetch;
 
@@ -47,7 +48,7 @@ describe('BitMEX trading – race between WS and REST', () => {
         const { hub, core } = createHub();
         const prepared = createPreparedLimit();
 
-        const mockFetch = jest.fn((input: RequestInfo | URL, init?: RequestInit) => {
+        const mockFetch = jest.fn((input: FetchRequestInfo | URL, init?: FetchRequestInit) => {
             const method = init?.method ?? 'GET';
 
             if (method !== 'POST') {

--- a/tests/integration/trading/stop-limit.flagged.spec.ts
+++ b/tests/integration/trading/stop-limit.flagged.spec.ts
@@ -5,6 +5,7 @@ import { OrderStatus } from '../../../src/domain/order';
 import { ValidationError } from '../../../src/infra/errors';
 import type { BitMex } from '../../../src/core/bitmex/index';
 import type { PreparedPlaceInput } from '../../../src/infra/validation';
+import type { FetchRequestInit, FetchRequestInfo } from '../../fetch-types';
 
 const ORIGINAL_FETCH = global.fetch;
 
@@ -94,7 +95,7 @@ describe('BitMEX trading – stop-limit flag', () => {
 
         expect(mockFetch).toHaveBeenCalledTimes(1);
 
-        const [, init] = mockFetch.mock.calls[0] as [RequestInfo | URL, RequestInit];
+        const [, init] = mockFetch.mock.calls[0] as [FetchRequestInfo | URL, FetchRequestInit];
         const body = JSON.parse(String(init.body));
 
         expect(body).toMatchObject({

--- a/tests/integration/trading/stop-market.lifecycle.spec.ts
+++ b/tests/integration/trading/stop-market.lifecycle.spec.ts
@@ -4,6 +4,7 @@ import { OrderStatus } from '../../../src/domain/order';
 import type { PreparedPlaceInput } from '../../../src/infra/validation';
 import { createScenario } from '../../helpers/ws-mock/scenario';
 import { setupPrivateHarness } from '../../helpers/privateHarness';
+import type { FetchRequestInit, FetchRequestInfo } from '../../fetch-types';
 
 const ORIGINAL_FETCH = global.fetch;
 
@@ -162,7 +163,7 @@ describe('BitMEX trading – stop-market lifecycle', () => {
 
         expect(mockFetch).toHaveBeenCalledTimes(1);
 
-        const [, init] = mockFetch.mock.calls[0] as [RequestInfo | URL, RequestInit];
+        const [, init] = mockFetch.mock.calls[0] as [FetchRequestInfo | URL, FetchRequestInit];
         const body = JSON.parse(String(init.body));
 
         expect(body).toMatchObject({

--- a/tests/integration/trading/timeout-reconcile.spec.ts
+++ b/tests/integration/trading/timeout-reconcile.spec.ts
@@ -5,6 +5,7 @@ import { OrderStatus } from '../../../src/domain/order';
 import { getCounterValue, resetMetrics } from '../../../src/infra/metrics';
 import type { BitMex } from '../../../src/core/bitmex/index';
 import type { PreparedPlaceInput } from '../../../src/infra/validation';
+import type { FetchRequestInit, FetchRequestInfo } from '../../fetch-types';
 
 const ORIGINAL_FETCH = global.fetch;
 
@@ -51,7 +52,7 @@ describe('BitMEX trading – timeout reconcile', () => {
 
         abortError.name = 'AbortError';
 
-        const mockFetch = jest.fn((input: RequestInfo | URL, init?: RequestInit) => {
+        const mockFetch = jest.fn((input: FetchRequestInfo | URL, init?: FetchRequestInit) => {
             const method = init?.method ?? 'GET';
 
             if (method === 'POST') {
@@ -109,8 +110,8 @@ describe('BitMEX trading – timeout reconcile', () => {
         expect(mockFetch).toHaveBeenCalledTimes(2);
 
         const [[postUrl, postInit], [getUrl, getInit]] = mockFetch.mock.calls as [
-            [RequestInfo | URL, RequestInit | undefined],
-            [RequestInfo | URL, RequestInit | undefined],
+            [FetchRequestInfo | URL, FetchRequestInit | undefined],
+            [FetchRequestInfo | URL, FetchRequestInit | undefined],
         ];
 
         expect(postInit?.method ?? 'GET').toBe('POST');

--- a/tests/rest/request.test.ts
+++ b/tests/rest/request.test.ts
@@ -3,6 +3,7 @@ import { jest } from '@jest/globals';
 import { BitmexRestClient } from '../../src/core/bitmex/rest/request';
 import { sign } from '../../src/core/bitmex/rest/sign';
 import { AuthError, ExchangeDownError, RateLimitError } from '../../src/infra/errors';
+import type { FetchRequestInit, FetchRequestInfo } from '../fetch-types';
 
 describe('BitmexRestClient.request()', () => {
     const originalFetch = global.fetch;
@@ -14,7 +15,7 @@ describe('BitmexRestClient.request()', () => {
 
     test('GET builds url with query string and returns JSON payload', async () => {
         const payload = [{ symbol: 'XBTUSD' }];
-        const mockFetch = jest.fn(async (input: RequestInfo | URL) => {
+        const mockFetch = jest.fn(async (input: FetchRequestInfo | URL) => {
             expect(String(input)).toBe('https://testnet.bitmex.com/api/v1/instrument/active?count=1');
 
             return new Response(JSON.stringify(payload), { status: 200 });
@@ -28,7 +29,7 @@ describe('BitmexRestClient.request()', () => {
         expect(data).toEqual(payload);
         expect(mockFetch).toHaveBeenCalledTimes(1);
 
-        const init = mockFetch.mock.calls[0][1] as RequestInit;
+        const init = mockFetch.mock.calls[0][1] as FetchRequestInit;
 
         expect(init.headers).toEqual({ accept: 'application/json' });
     });
@@ -66,7 +67,7 @@ describe('BitmexRestClient.request()', () => {
             body: { symbol: 'XBTUSD', orderQty: 1 },
         });
 
-        const [, init] = mockFetch.mock.calls[0] as [RequestInfo | URL, RequestInit];
+        const [, init] = mockFetch.mock.calls[0] as [FetchRequestInfo | URL, FetchRequestInit];
         const headers = init.headers as Record<string, string>;
 
         expect(headers['content-type']).toBe('application/json');
@@ -104,7 +105,7 @@ describe('BitmexRestClient.request()', () => {
 
             await client.request('POST', '/api/v1/order', { auth: true, body: { symbol: 'XBTUSD' } });
 
-            const [, init] = mockFetch.mock.calls[0] as [RequestInfo | URL, RequestInit];
+            const [, init] = mockFetch.mock.calls[0] as [FetchRequestInfo | URL, FetchRequestInit];
             const headers = init.headers as Record<string, string>;
             const expectedExpires = Math.floor(1_700_000_000_000 / 1000) + 30;
 
@@ -140,7 +141,7 @@ describe('BitmexRestClient.request()', () => {
 
             await client.request('POST', '/api/v1/order', { auth: true, body: { symbol: 'XBTUSD' } });
 
-            const [, init] = mockFetch.mock.calls[0] as [RequestInfo | URL, RequestInit];
+            const [, init] = mockFetch.mock.calls[0] as [FetchRequestInfo | URL, FetchRequestInit];
             const headers = init.headers as Record<string, string>;
             const expectedExpires = Math.floor(1_750_000_000_000 / 1000) + 45;
 


### PR DESCRIPTION
## Summary
- add shared fetch request type aliases for tests
- update test suites to use the shared fetch types to resolve RequestInit no-undef lint errors

## Testing
- npm run lint *(fails with pre-existing lint violations unrelated to RequestInit)*

------
https://chatgpt.com/codex/tasks/task_e_68d102bf0a448320a4c1700dbb048dea