### PR TITLE
Replace readonly modifiers with private fields and getters

### DIFF
--- a/src/core/bitmex/rest/request.ts
+++ b/src/core/bitmex/rest/request.ts
@@ -27,22 +27,42 @@ export interface BitmexRestClientOptions {
 }
 
 export class BitmexRestClient {
-    readonly baseUrl: string;
-    readonly apiKey?: string;
-    readonly apiSecret?: string;
-    readonly defaultTimeoutMs: number;
-    readonly apiExpiresSkewSec: number;
+    #baseUrl: string;
+    #apiKey?: string;
+    #apiSecret?: string;
+    #defaultTimeoutMs: number;
+    #apiExpiresSkewSec: number;
 
     constructor(opts: BitmexRestClientOptions = {}) {
-        this.baseUrl = opts.isTest ? BITMEX_REST_HOSTS.testnet : BITMEX_REST_HOSTS.mainnet;
-        this.apiKey = opts.apiKey;
-        this.apiSecret = opts.apiSecret;
-        this.defaultTimeoutMs = opts.defaultTimeoutMs ?? BITMEX_REST_DEFAULT_TIMEOUT_MS;
-        this.apiExpiresSkewSec = resolveExpiresSkewSec(opts.apiExpiresSkewSec);
+        this.#baseUrl = opts.isTest ? BITMEX_REST_HOSTS.testnet : BITMEX_REST_HOSTS.mainnet;
+        this.#apiKey = opts.apiKey;
+        this.#apiSecret = opts.apiSecret;
+        this.#defaultTimeoutMs = opts.defaultTimeoutMs ?? BITMEX_REST_DEFAULT_TIMEOUT_MS;
+        this.#apiExpiresSkewSec = resolveExpiresSkewSec(opts.apiExpiresSkewSec);
+    }
+
+    get baseUrl(): string {
+        return this.#baseUrl;
+    }
+
+    get apiKey(): string | undefined {
+        return this.#apiKey;
+    }
+
+    get apiSecret(): string | undefined {
+        return this.#apiSecret;
+    }
+
+    get defaultTimeoutMs(): number {
+        return this.#defaultTimeoutMs;
+    }
+
+    get apiExpiresSkewSec(): number {
+        return this.#apiExpiresSkewSec;
     }
 
     async request<T>(method: HttpMethod, path: string, init: RequestInitEx = {}): Promise<T> {
-        const url = new URL(path, this.baseUrl);
+        const url = new URL(path, this.#baseUrl);
 
         if (init.qs) {
             for (const [key, value] of Object.entries(init.qs)) {
@@ -68,7 +88,7 @@ export class BitmexRestClient {
             headers['content-type'] = 'application/json';
         }
 
-        const hasCredentials = Boolean(this.apiKey && this.apiSecret);
+        const hasCredentials = Boolean(this.#apiKey && this.#apiSecret);
         const shouldSign = init.auth ?? (hasCredentials && path.startsWith('/api/'));
 
         if (shouldSign) {
@@ -76,16 +96,16 @@ export class BitmexRestClient {
                 throw AuthError.badCredentials('BitMEX API credentials required', { exchange: 'BitMEX' });
             }
 
-            const expires = Math.floor(Date.now() / 1000) + this.apiExpiresSkewSec;
-            const signature = sign(method, pathWithQuery, expires, payloadBody, this.apiSecret!);
+            const expires = Math.floor(Date.now() / 1000) + this.#apiExpiresSkewSec;
+            const signature = sign(method, pathWithQuery, expires, payloadBody, this.#apiSecret!);
 
-            headers['api-key'] = this.apiKey!;
+            headers['api-key'] = this.#apiKey!;
             headers['api-expires'] = String(expires);
             headers['api-signature'] = signature;
         }
 
         const controller = new AbortController();
-        const timeoutMs = init.timeoutMs ?? this.defaultTimeoutMs;
+        const timeoutMs = init.timeoutMs ?? this.#defaultTimeoutMs;
         const timeout = setTimeout(() => controller.abort(), timeoutMs);
 
         try {

--- a/src/domain/instrument.ts
+++ b/src/domain/instrument.ts
@@ -245,7 +245,11 @@ const WRITABLE_FIELDS: (keyof InstrumentShape)[] = [
 ];
 
 export class Instrument extends EventEmitter {
-    static readonly DEFAULT_TRADE_BUFFER_SIZE = 1_000;
+    static #DEFAULT_TRADE_BUFFER_SIZE = 1_000;
+
+    static get DEFAULT_TRADE_BUFFER_SIZE(): number {
+        return Instrument.#DEFAULT_TRADE_BUFFER_SIZE;
+    }
 
     static normalizeTradeBufferSize(size?: number): number {
         if (!Number.isFinite(size)) {
@@ -287,7 +291,11 @@ export class Instrument extends EventEmitter {
     expiry?: Nullable<string>;
     timestamp?: Nullable<string>;
     priceFilters: InstrumentPriceFilters;
-    readonly trades: InstrumentTradesBuffer;
+    #trades: InstrumentTradesBuffer;
+
+    get trades(): InstrumentTradesBuffer {
+        return this.#trades;
+    }
 
     get orderBook(): OrderBookL2 {
         if (!this.#orderBook) {
@@ -387,7 +395,7 @@ export class Instrument extends EventEmitter {
         this.symbolNative = data.symbolNative;
         this.symbolUni = data.symbolUni;
         this.priceFilters = {};
-        this.trades = new InstrumentTradesBuffer(bufferSize, (trades, meta) =>
+        this.#trades = new InstrumentTradesBuffer(bufferSize, (trades, meta) =>
             this.#handleTradesInserted(trades, meta),
         );
         this.#tradeEventEnabled = tradeEventEnabled ?? false;

--- a/src/domain/order.ts
+++ b/src/domain/order.ts
@@ -79,7 +79,7 @@ export type OrderUpdateContext = {
 };
 
 export class Order extends EventEmitter implements BaseEntity<OrderSnapshot> {
-    readonly orderId: OrderID;
+    #orderId: OrderID;
 
     #clOrdId: ClOrdID | null = null;
     #symbol: Symbol;
@@ -129,7 +129,7 @@ export class Order extends EventEmitter implements BaseEntity<OrderSnapshot> {
             throw new TypeError('Order requires a non-empty orderId');
         }
 
-        this.orderId = orderId.trim();
+        this.#orderId = orderId.trim();
         this.#clOrdId = normalizeId(clOrdId);
         this.#symbol = normalizeSymbol(symbol);
         this.#status = status ?? OrderStatus.Placed;
@@ -160,6 +160,10 @@ export class Order extends EventEmitter implements BaseEntity<OrderSnapshot> {
             this.#avgFillPrice = null;
             this.#fillValue = 0;
         }
+    }
+
+    get orderId(): OrderID {
+        return this.#orderId;
     }
 
     get clOrdId(): ClOrdID | null {

--- a/src/domain/orderBookL2.ts
+++ b/src/domain/orderBookL2.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from 'node:events';
 
-import { createLogger } from '../infra/logger';
+import { createLogger, type Logger } from '../infra/logger';
 import type { L2BatchDelta, L2Best, L2Row } from '../types/orderbook';
 
 type L2UpdateRow = Pick<L2Row, 'id'> & Partial<Omit<L2Row, 'id'>>;
@@ -11,9 +11,17 @@ type PriceLevel = {
 };
 
 export class OrderBookL2 extends EventEmitter {
-    readonly log = createLogger('orderbook:l2');
+    #log: Logger = createLogger('orderbook:l2');
 
-    readonly rows = new Map<number, L2Row>();
+    #rows = new Map<number, L2Row>();
+
+    get log(): Logger {
+        return this.#log;
+    }
+
+    get rows(): Map<number, L2Row> {
+        return this.#rows;
+    }
 
     bestBid: L2Best | null = null;
     bestAsk: L2Best | null = null;
@@ -58,7 +66,7 @@ export class OrderBookL2 extends EventEmitter {
     }
 
     reset(snapshot: L2Row[]): void {
-        this.rows.clear();
+        this.#rows.clear();
         this.#levels.buy.clear();
         this.#levels.sell.clear();
         this.bestBid = null;
@@ -107,7 +115,7 @@ export class OrderBookL2 extends EventEmitter {
         const touched = new Set<'buy' | 'sell'>();
 
         for (const update of rows) {
-            const current = this.rows.get(update.id);
+            const current = this.#rows.get(update.id);
 
             if (!current) {
                 this.outOfSync = true;
@@ -160,7 +168,7 @@ export class OrderBookL2 extends EventEmitter {
         const touched = new Set<'buy' | 'sell'>();
 
         for (const id of ids) {
-            const current = this.rows.get(id);
+            const current = this.#rows.get(id);
 
             if (!current) {
                 this.outOfSync = true;
@@ -175,7 +183,7 @@ export class OrderBookL2 extends EventEmitter {
                 asks += 1;
             }
 
-            this.rows.delete(id);
+            this.#rows.delete(id);
             this.#removeFromLevel(current.side, current.price, current.id, current.size);
         }
 
@@ -191,9 +199,9 @@ export class OrderBookL2 extends EventEmitter {
             return false;
         }
 
-        if (this.rows.has(row.id)) {
+        if (this.#rows.has(row.id)) {
             this.outOfSync = true;
-            this.log.warn('duplicate L2 id', { id: row.id });
+            this.#log.warn('duplicate L2 id', { id: row.id });
 
             return false;
         }
@@ -205,7 +213,7 @@ export class OrderBookL2 extends EventEmitter {
             size: row.size,
         };
 
-        this.rows.set(normalized.id, normalized);
+        this.#rows.set(normalized.id, normalized);
         this.#addToLevel(normalized);
 
         return true;
@@ -221,7 +229,7 @@ export class OrderBookL2 extends EventEmitter {
             return;
         }
 
-        const previous = this.rows.get(row.id);
+        const previous = this.#rows.get(row.id);
 
         if (previous) {
             const delta = row.size - previous.size;

--- a/src/infra/errors.ts
+++ b/src/infra/errors.ts
@@ -43,13 +43,13 @@ export interface ErrorOptions {
 type ErrorOverrides = Partial<Omit<ErrorOptions, 'code'>>;
 
 export class BaseError extends Error {
-    readonly category: ErrorCode;
-    override readonly cause?: unknown;
-    readonly details?: Record<string, unknown>;
-    readonly httpStatus?: number;
-    readonly retryAfterMs?: number;
-    readonly exchange?: string;
-    readonly requestId?: string;
+    #category: ErrorCode;
+    #cause?: unknown;
+    #details?: Record<string, unknown>;
+    #httpStatus?: number;
+    #retryAfterMs?: number;
+    #exchange?: string;
+    #requestId?: string;
 
     constructor(opts: ErrorOptions) {
         const message = opts.message ?? opts.code;
@@ -57,13 +57,13 @@ export class BaseError extends Error {
         super(message);
 
         this.name = new.target.name;
-        this.category = opts.code;
-        this.cause = opts.cause;
-        this.details = opts.details;
-        this.httpStatus = opts.httpStatus;
-        this.retryAfterMs = opts.retryAfterMs;
-        this.exchange = opts.exchange;
-        this.requestId = opts.requestId;
+        this.#category = opts.code;
+        this.#cause = opts.cause;
+        this.#details = opts.details;
+        this.#httpStatus = opts.httpStatus;
+        this.#retryAfterMs = opts.retryAfterMs;
+        this.#exchange = opts.exchange;
+        this.#requestId = opts.requestId;
 
         const captureStackTrace = (Error as { captureStackTrace?: CaptureStackTraceFn }).captureStackTrace;
 
@@ -74,12 +74,40 @@ export class BaseError extends Error {
         Object.setPrototypeOf(this, new.target.prototype);
     }
 
+    get category(): ErrorCode {
+        return this.#category;
+    }
+
+    override get cause(): unknown | undefined {
+        return this.#cause;
+    }
+
+    get details(): Record<string, unknown> | undefined {
+        return this.#details;
+    }
+
+    get httpStatus(): number | undefined {
+        return this.#httpStatus;
+    }
+
+    get retryAfterMs(): number | undefined {
+        return this.#retryAfterMs;
+    }
+
+    get exchange(): string | undefined {
+        return this.#exchange;
+    }
+
+    get requestId(): string | undefined {
+        return this.#requestId;
+    }
+
     get code(): ErrorCode | AuthErrorCode {
-        return this.category;
+        return this.#category;
     }
 
     isRetryable(): boolean {
-        switch (this.category) {
+        switch (this.#category) {
             case 'NETWORK_ERROR':
             case 'RATE_LIMIT':
             case 'EXCHANGE_DOWN':
@@ -94,14 +122,14 @@ export class BaseError extends Error {
         return {
             name: this.name,
             code: this.code,
-            category: this.category,
+            category: this.#category,
             message: this.message,
-            httpStatus: this.httpStatus,
-            retryAfterMs: this.retryAfterMs,
-            exchange: this.exchange,
-            requestId: this.requestId,
-            details: this.details ? sanitizeRecord(this.details) : undefined,
-            cause: formatCause(this.cause),
+            httpStatus: this.#httpStatus,
+            retryAfterMs: this.#retryAfterMs,
+            exchange: this.#exchange,
+            requestId: this.#requestId,
+            details: this.#details ? sanitizeRecord(this.#details) : undefined,
+            cause: formatCause(this.#cause),
             stack: this.stack,
         };
     }
@@ -114,7 +142,7 @@ export class NetworkError extends BaseError {
 }
 
 export class AuthError extends BaseError {
-    readonly authCode: AuthErrorCode;
+    #authCode: AuthErrorCode;
 
     constructor(
         message = 'Authentication error',
@@ -122,11 +150,15 @@ export class AuthError extends BaseError {
         opts: Omit<ErrorOptions, 'code' | 'message'> = {},
     ) {
         super({ code: 'AUTH_ERROR', message, ...opts });
-        this.authCode = code;
+        this.#authCode = code;
+    }
+
+    get authCode(): AuthErrorCode {
+        return this.#authCode;
     }
 
     override get code(): AuthErrorCode {
-        return this.authCode;
+        return this.#authCode;
     }
 
     static badCredentials(

--- a/tests/bitmex/instrument.test.ts
+++ b/tests/bitmex/instrument.test.ts
@@ -13,12 +13,16 @@ import type { BitMexInstrument } from '../../src/core/bitmex/types';
 import type { Settings } from '../../src/types';
 
 class FakeWebSocket {
-    readonly url: string;
+    #url: string;
     onmessage: ((event: { data: unknown }) => void) | null = null;
     #listeners = new Map<string, Set<(...args: unknown[]) => void>>();
 
     constructor(url: string) {
-        this.url = url;
+        this.#url = url;
+    }
+
+    get url(): string {
+        return this.#url;
     }
 
     addEventListener(event: string, listener: (...args: unknown[]) => void): void {

--- a/tests/bitmex/orderbook.unit.test.ts
+++ b/tests/bitmex/orderbook.unit.test.ts
@@ -7,7 +7,7 @@ import type { BitMexInstrument } from '../../src/core/bitmex/types';
 import type { L2Row } from '../../src/types/orderbook';
 
 class NoopWebSocket {
-    readonly url: string;
+    #url: string;
     onmessage: ((event: { data: unknown }) => void) | null = null;
     onopen: (() => void) | null = null;
     onerror: ((err: unknown) => void) | null = null;
@@ -16,7 +16,11 @@ class NoopWebSocket {
     #listeners = new Map<string, Set<(...args: unknown[]) => void>>();
 
     constructor(url: string) {
-        this.url = url;
+        this.#url = url;
+    }
+
+    get url(): string {
+        return this.#url;
     }
 
     addEventListener(event: string, listener: (...args: unknown[]) => void): void {

--- a/tests/bitmex/trade.test.ts
+++ b/tests/bitmex/trade.test.ts
@@ -9,12 +9,16 @@ import type { BitmexTradeRaw } from '../../src/types/bitmex';
 import type { Settings } from '../../src/types';
 
 class FakeWebSocket {
-    readonly url: string;
+    #url: string;
     onmessage: ((event: { data: unknown }) => void) | null = null;
     #listeners = new Map<string, Set<(...args: unknown[]) => void>>();
 
     constructor(url: string) {
-        this.url = url;
+        this.#url = url;
+    }
+
+    get url(): string {
+        return this.#url;
     }
 
     addEventListener(event: string, listener: (...args: unknown[]) => void): void {

--- a/tests/helpers/privateHarness.ts
+++ b/tests/helpers/privateHarness.ts
@@ -121,7 +121,7 @@ function createNoopWebSocket(): {
     const OriginalWebSocket = (globalThis as any).WebSocket;
 
     class NoopSocket {
-        readonly url: string;
+        #url: string;
         onopen: (() => void) | null = null;
         onmessage: ((event: { data: unknown }) => void) | null = null;
         onclose: ((event?: { code?: number; reason?: string }) => void) | null = null;
@@ -130,7 +130,11 @@ function createNoopWebSocket(): {
         #listeners = new Map<string, Set<(...args: unknown[]) => void>>();
 
         constructor(url: string) {
-            this.url = url;
+            this.#url = url;
+        }
+
+        get url(): string {
+            return this.#url;
         }
 
         addEventListener(event: string, listener: (...args: unknown[]) => void): void {

--- a/tests/helpers/ws-mock/scenario.ts
+++ b/tests/helpers/ws-mock/scenario.ts
@@ -199,10 +199,14 @@ export class ScenarioBuilder {
 }
 
 export class ScenarioScript {
-    readonly events: readonly ScenarioEvent[];
+    #events: readonly ScenarioEvent[];
 
     constructor(events: readonly ScenarioEvent[]) {
-        this.events = events;
+        this.#events = events;
+    }
+
+    get events(): readonly ScenarioEvent[] {
+        return this.#events;
     }
 }
 

--- a/tests/helpers/ws-mock/server.ts
+++ b/tests/helpers/ws-mock/server.ts
@@ -7,7 +7,7 @@ import type { PrivateTable, ScenarioEvent, ScenarioScript } from './scenario';
 type MessagePredicate = (message: unknown) => boolean;
 
 class SessionContext {
-    readonly socket: WebSocket;
+    #socket: WebSocket;
     #clock: TestClock;
     #messages: unknown[] = [];
     #closed = false;
@@ -16,7 +16,7 @@ class SessionContext {
     #nextAuthMode: 'success' | 'already-authed' = 'success';
 
     constructor(socket: WebSocket, clock: TestClock) {
-        this.socket = socket;
+        this.#socket = socket;
         this.#clock = clock;
         this.#closedPromise = new Promise<void>(resolve => {
             this.#resolveClosed = resolve;
@@ -32,6 +32,10 @@ class SessionContext {
             this.#closed = true;
             this.#resolveClosed();
         });
+    }
+
+    get socket(): WebSocket {
+        return this.#socket;
     }
 
     requireAuth(): void {
@@ -54,7 +58,7 @@ class SessionContext {
                 ? { success: false, error: 'Already authenticated', request }
                 : { success: true, request };
 
-        this.socket.send(JSON.stringify(response));
+        this.#socket.send(JSON.stringify(response));
         this.#nextAuthMode = 'success';
     }
 
@@ -85,18 +89,18 @@ class SessionContext {
                 request: { op: 'subscribe', args: channels },
             };
 
-            this.socket.send(JSON.stringify(payload));
+            this.#socket.send(JSON.stringify(payload));
         }
     }
 
     sendChannel(table: PrivateTable, action: 'partial' | 'insert' | 'update' | 'delete', data: unknown[]): void {
         const payload = { table, action, data };
 
-        this.socket.send(JSON.stringify(payload));
+        this.#socket.send(JSON.stringify(payload));
     }
 
     drop(code?: number, reason?: string): void {
-        this.socket.close(code ?? 4000, reason ?? 'scenario-drop');
+        this.#socket.close(code ?? 4000, reason ?? 'scenario-drop');
     }
 
     waitForClose(): Promise<void> {

--- a/tests/integration/private/order-stream.test.ts
+++ b/tests/integration/private/order-stream.test.ts
@@ -7,12 +7,16 @@ import type { BitMexOrder } from '../../../src/core/bitmex/types';
 import type { Settings } from '../../../src/types';
 
 class FakeWebSocket {
-    readonly url: string;
+    #url: string;
     onmessage: ((event: { data: unknown }) => void) | null = null;
     #listeners = new Map<string, Set<(...args: unknown[]) => void>>();
 
     constructor(url: string) {
-        this.url = url;
+        this.#url = url;
+    }
+
+    get url(): string {
+        return this.#url;
     }
 
     addEventListener(event: string, listener: (...args: unknown[]) => void): void {

--- a/tests/integration/private/position-stream.test.ts
+++ b/tests/integration/private/position-stream.test.ts
@@ -17,7 +17,7 @@ let metrics!: MetricsModule;
 class ControlledWebSocket {
     static instances: ControlledWebSocket[] = [];
 
-    readonly url: string;
+    #url: string;
     onmessage: ((event: { data: unknown }) => void) | null = null;
     onopen: (() => void) | null = null;
     onerror: ((err: unknown) => void) | null = null;
@@ -26,8 +26,12 @@ class ControlledWebSocket {
     #listeners = new Map<string, Set<(...args: unknown[]) => void>>();
 
     constructor(url: string) {
-        this.url = url;
+        this.#url = url;
         ControlledWebSocket.instances.push(this);
+    }
+
+    get url(): string {
+        return this.#url;
     }
 
     addEventListener(event: string, listener: (...args: unknown[]) => void): void {

--- a/tests/integration/private/wallet-stream.test.ts
+++ b/tests/integration/private/wallet-stream.test.ts
@@ -349,7 +349,7 @@ describe('BitMEX wallet stream', () => {
 class ControlledWebSocket {
     static instances: ControlledWebSocket[] = [];
 
-    readonly url: string;
+    #url: string;
     onmessage: ((event: { data: unknown }) => void) | null = null;
     onopen: (() => void) | null = null;
     onerror: ((err: unknown) => void) | null = null;
@@ -358,8 +358,12 @@ class ControlledWebSocket {
     #listeners = new Map<string, Set<(...args: unknown[]) => void>>();
 
     constructor(url: string) {
-        this.url = url;
+        this.#url = url;
         ControlledWebSocket.instances.push(this);
+    }
+
+    get url(): string {
+        return this.#url;
     }
 
     addEventListener(event: string, listener: (...args: unknown[]) => void): void {

--- a/tests/ws/orderbook.smoke.test.ts
+++ b/tests/ws/orderbook.smoke.test.ts
@@ -43,7 +43,7 @@ beforeAll(async () => {
 class ControlledWebSocket {
     static instances: ControlledWebSocket[] = [];
 
-    readonly url: string;
+    #url: string;
     onmessage: ((event: { data: unknown }) => void) | null = null;
     onopen: (() => void) | null = null;
     onerror: ((err: unknown) => void) | null = null;
@@ -52,8 +52,12 @@ class ControlledWebSocket {
     #listeners = new Map<string, Set<(...args: unknown[]) => void>>();
 
     constructor(url: string) {
-        this.url = url;
+        this.#url = url;
         ControlledWebSocket.instances.push(this);
+    }
+
+    get url(): string {
+        return this.#url;
     }
 
     addEventListener(event: string, listener: (...args: unknown[]) => void): void {

--- a/tests/ws/trade.smoke.test.ts
+++ b/tests/ws/trade.smoke.test.ts
@@ -9,7 +9,7 @@ import type { BitmexTradeRaw } from '../../src/types/bitmex';
 class ControlledWebSocket {
     static instances: ControlledWebSocket[] = [];
 
-    readonly url: string;
+    #url: string;
     onmessage: ((event: { data: unknown }) => void) | null = null;
     onopen: (() => void) | null = null;
     onerror: ((err: unknown) => void) | null = null;
@@ -18,8 +18,12 @@ class ControlledWebSocket {
     #listeners = new Map<string, Set<(...args: unknown[]) => void>>();
 
     constructor(url: string) {
-        this.url = url;
+        this.#url = url;
         ControlledWebSocket.instances.push(this);
+    }
+
+    get url(): string {
+        return this.#url;
     }
 
     addEventListener(event: string, listener: (...args: unknown[]) => void): void {


### PR DESCRIPTION
## Summary
- refactor BitmexRestClient configuration properties to use private `#` fields with getters instead of `readonly`
- update Instrument, Order, OrderBookL2, and error hierarchy classes to follow the same private-field pattern
- align test WebSocket doubles and scenario helpers with the new `#field + getter` convention

## Testing
- npm run lint *(fails: existing `NodeJS` globals and accessibility modifier violations left untouched as instructed)*

------
https://chatgpt.com/codex/tasks/task_e_68d1160e648483208f8a4cbb1d12da3d